### PR TITLE
Use more bytes :smile: 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ varint-rs = "2"
 fmmap = { version = "0.3", features = ["tokio-async"] }
 reqwest = { version = "0.11", features = ["rustls-tls-webpki-roots"] }
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
+flate2 = "1.0.24"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -218,7 +218,7 @@ pub trait AsyncBackend {
     }
 }
 
-#[cfg(all(feature = "mmap-async-tokio", test))]
+#[cfg(test)]
 mod tests {
     use std::path::Path;
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -218,7 +218,7 @@ pub trait AsyncBackend {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "mmap-async-tokio", test))]
 mod tests {
     use std::path::Path;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,6 @@ pub mod http;
 #[cfg(feature = "mmap-async-tokio")]
 pub mod mmap;
 
-#[cfg(feature = "tokio")]
+#[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 pub mod async_reader;
 pub mod tile;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,4 +1,5 @@
 use crate::{Compression, TileType};
+use bytes::Bytes;
 use hilbert_2d::Variant;
 
 pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
@@ -15,7 +16,7 @@ pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
 }
 
 pub struct Tile {
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub tile_type: TileType,
     pub tile_compression: Compression,
 }


### PR DESCRIPTION
Replaces most use of `&[u8]` with the cheap `Bytes` to simplify the logic and reduce the number of necessary copies. This works quite well with mmap and http backends, which both use `Bytes` under the hood, resulting in zero-copy throughout the entire tile delivery code path.

Closes #5.