### PR TITLE
Rework to parse tilejson, refactorings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,21 @@ jobs:
         with:
           command: test
           args: --all-targets --all-features
+
+      - name: Test http-async
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features http-async
+
+      - name: Test mmap-async-tokio
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features mmap-async-tokio
+
+      - name: Test tilejson
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features tilejson

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>"]
 license = "MIT OR Apache-2.0"
@@ -12,6 +12,7 @@ keywords = ["pmtiles", "gis", "geo"]
 default = []
 http-async = ["reqwest", "tokio"]
 mmap-async-tokio = ["fmmap", "fmmap/tokio-async", "tokio"]
+tilejson = ["dep:tilejson", "serde", "serde_json"]
 
 # TODO: support other async libraries
 
@@ -24,9 +25,11 @@ bytes = "1"
 fmmap = { version = "0.3", default-features = false, optional = true }
 hilbert_2d = "1"
 reqwest = { version = "0.11", default-features = false, optional = true }
-tilejson = "0.3"
 tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
 varint-rs = "2"
+tilejson = { version = "0.3", optional = true }
+serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 fmmap = { version = "0.3", features = ["tokio-async"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+## These should be enabled in the future, but for now its a manual step to simplify usage.
+## Use cargo nightly for these:
+####  cargo +nightly fmt
+#imports_granularity = "Module"
+#group_imports = "StdExternalCrate"

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
 use bytes::Bytes;
-use reqwest::{
-    header::{HeaderValue, ACCEPT_RANGES, RANGE},
-    Client, IntoUrl, Method, Request, Url,
-};
+use reqwest::header::{HeaderValue, ACCEPT_RANGES, RANGE};
+use reqwest::{Client, IntoUrl, Method, Request, Url};
 
-use crate::{async_reader::AsyncBackend, error::Error};
+use crate::async_reader::AsyncBackend;
+use crate::error::Error;
 
 pub struct HttpBackend {
     client: Client,
@@ -81,15 +80,9 @@ mod tests {
 
     #[tokio::test]
     async fn basic_http_test() {
-        let client = reqwest::Client::builder()
-            .use_rustls_tls()
-            .build()
-            .expect("Unable to create HTTP client.");
-        let backend =
-            HttpBackend::try_from(client, TEST_URL).expect("Unable to build HTTP backend.");
+        let client = reqwest::Client::builder().use_rustls_tls().build().unwrap();
+        let backend = HttpBackend::try_from(client, TEST_URL).unwrap();
 
-        let _tiles = AsyncPmTilesReader::try_from_source(backend)
-            .await
-            .expect("Unable to init PMTiles archive");
+        let _tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-// TODO: delete this!!!
-// TODO: delete this!!!
-// TODO: delete this!!!
-#![allow(dead_code)]
-
 pub use crate::header::{Compression, Header, TileType};
 
 mod directory;
@@ -18,3 +13,9 @@ pub mod mmap;
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 pub mod async_reader;
 pub mod tile;
+
+#[cfg(test)]
+mod tests {
+    pub const RASTER_FILE: &str = "fixtures/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles";
+    pub const VECTOR_FILE: &str = "fixtures/protomaps(vector)ODbL_firenze.pmtiles";
+}

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -5,14 +5,15 @@ use async_trait::async_trait;
 use bytes::{Buf, Bytes};
 use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt, AsyncOptions};
 
-use crate::{async_reader::AsyncBackend, error::Error};
+use crate::async_reader::AsyncBackend;
+use crate::error::Error;
 
 pub struct MmapBackend {
     file: AsyncMmapFile,
 }
 
 impl MmapBackend {
-    pub async fn try_from(p: &Path) -> Result<Self, Error> {
+    pub async fn try_from<P: AsRef<Path>>(p: P) -> Result<Self, Error> {
         Ok(Self {
             file: AsyncMmapFile::open_with_options(p, AsyncOptions::new().read(true))
                 .await

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,7 +1,8 @@
-use crate::{Compression, TileType};
 use bytes::Bytes;
-use hilbert_2d::Variant;
 
+use crate::{Compression, TileType};
+
+#[cfg(any(feature = "http-async", feature = "mmap-async-tokio", test))]
 pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
     if z == 0 {
         return 0;
@@ -9,8 +10,12 @@ pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
 
     let base_id: u64 = 1 + (1..z).map(|i| 4u64.pow(i as u32)).sum::<u64>();
 
-    let tile_id =
-        hilbert_2d::xy2h_discrete(x as usize, y as usize, z as usize, Variant::Hilbert) as u64;
+    let tile_id = hilbert_2d::xy2h_discrete(
+        x as usize,
+        y as usize,
+        z as usize,
+        hilbert_2d::Variant::Hilbert,
+    ) as u64;
 
     base_id + tile_id
 }


### PR DESCRIPTION
* when `tilejson` feature is enabled, add tilejson creation and parsing. Without it, serde, tilejson, and serde-json are not enabled.

* added a more standard way to do code fmt (nightly only, so disabled by default)

* refactored to keep it a bit cleaner, and removed all the `.expected` from tests - they make tests harder to read, while doing the same as unwrap. If they fail, it's a big red flag anyway - that's what tests are for.

* made conditional compilation more straightforward, removing the dead code warnings