### PR TITLE
Always use minzoom/maxzoom from header, ignore minzoom/maxzoom metadata

### DIFF
--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -113,6 +113,9 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
                     tj.name = Some(v);
                 } else if key == "version" {
                     tj.version = Some(v);
+                } else if key == "minzoom" || key == "maxzoom" {
+                    // We already have the correct values from the header, so just drop these
+                    // attributes from the metadata silently, don't overwrite known-good values.
                 } else {
                     tj.other.insert(key, Value::String(v));
                 }


### PR DESCRIPTION
In workflows where MBTiles are converted to PMTiles, we might end up with the minzoom/maxzoom string attributes from the MBTiles metatada table in the PMTiles JSON metadata. If we copied that over, we would end up with string values in the TileJSON, confusing/breaking clients.

I noticed this with MapLibre: When zooming in to a zoom level of 15, it requested tiles for this zoom level from the server, subsequently showing only a gray map because the server didn't have the tiles.

Steps to demonstrate the problem:
```sh
> curl -o andorra.osm.pbf https://download.geofabrik.de/europe/andorra-latest.osm.pbf
> tilemaker --input andorra.osm.pbf --output andorra.mbtiles
> sqlite3 andorra.mbtiles '.mode insert' 'select * from metadata where name in ("minzoom", "maxzoom");'
INSERT INTO "table" VALUES('maxzoom','14');
INSERT INTO "table" VALUES('minzoom','0');
> pmtiles convert andorra.mbtiles andorra.pmtiles
> pmtiles show andorra.pmtiles | grep '^m.*zoom'
min zoom: 0
max zoom: 14
maxzoom 14
minzoom 0
> martin andorra.pmtiles
> curl -s http://localhost:3000/andorra | jq '{minzoom, maxzoom}'
{
  "minzoom": "0",
  "maxzoom": "14"
}
```
Workaround that is necessary without this patch:
```sh
> sqlite3 andorra.mbtiles 'delete from metadata where name in ("minzoom", "maxzoom");'
> pmtiles convert andorra.mbtiles andorra.pmtiles
> pmtiles show andorra.pmtiles | grep '^m.*zoom'
min zoom: 0
max zoom: 14
> martin andorra.pmtiles
> curl -s http://localhost:3000/andorra | jq '{minzoom, maxzoom}'
{
  "minzoom": 0,
  "maxzoom": 14
}
```
(using https://github.com/systemed/tilemaker, https://github.com/protomaps/go-pmtiles, https://github.com/maplibre/martin)