### PR TITLE
Fix incorrect 206-partial handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,8 @@ pub enum HttpError {
     ResponseBodyTooLong(usize, usize),
     #[error("HTTP error {0}")]
     Http(#[from] reqwest::Error),
+    #[error("{0}")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
 }
 
 // This is required because thiserror #[from] does not support two-level conversion.


### PR DESCRIPTION
Per [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests), `Accept-Ranges` response is returned ONLY when using HEAD request without the `Range` header. When asking for a specific range, the server must reply with 206 status.

Also did a minor cleanup for the header settings