### PR TITLE
Refactor to cleanup and prepare for directory caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,4 @@ jobs:
       - run: cargo test --features http-async
       - run: cargo test --features mmap-async-tokio
       - run: cargo test --features tilejson
+      - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>"]
 license = "MIT OR Apache-2.0"
@@ -36,10 +36,10 @@ tokio = { version = "1", default-features = false, features = ["io-util"], optio
 varint-rs = "2"
 
 [dev-dependencies]
+flate2 = "1"
 fmmap = { version = "0.3", features = ["tokio-async"] }
 reqwest = { version = "0.11", features = ["rustls-tls-webpki-roots"] }
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
-flate2 = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ test:
     cargo test --features http-async
     cargo test --features mmap-async-tokio
     cargo test --features tilejson
+    cargo test
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 
 # Run cargo fmt and cargo clippy
@@ -25,7 +26,7 @@ fmt:
 
 # Run cargo clippy
 clippy:
-    cargo clippy --workspace --all-targets --bins --tests --lib --benches -- -D warnings
+    cargo clippy --workspace --all-targets --all-features --bins --tests --lib --benches -- -D warnings
 
 # Build and open code documentation
 docs:

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -25,7 +25,7 @@ impl Directory {
                 // https://github.com/protomaps/PMTiles/blob/9c7f298fb42290354b8ed0a9b2f50e5c0d270c40/js/index.ts#L210
                 if next_id > 0 {
                     let previous_tile = self.entries.get(next_id - 1)?;
-                    if previous_tile.run_length == 0
+                    if previous_tile.is_leaf()
                         || tile_id - previous_tile.tile_id < previous_tile.run_length as u64
                     {
                         return Some(previous_tile);
@@ -86,6 +86,13 @@ pub(crate) struct Entry {
     pub(crate) offset: u64,
     pub(crate) length: u32,
     pub(crate) run_length: u32,
+}
+
+#[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
+impl Entry {
+    pub fn is_leaf(&self) -> bool {
+        self.run_length == 0
+    }
 }
 
 #[cfg(test)]

--- a/src/header.rs
+++ b/src/header.rs
@@ -80,18 +80,26 @@ impl Header {
             tiles: sources,
             minzoom: self.min_zoom,
             maxzoom: self.max_zoom,
-            bounds: tilejson::Bounds::new(
-                self.min_longitude as f64,
-                self.min_latitude as f64,
-                self.max_longitude as f64,
-                self.max_latitude as f64,
-            ),
-            center: tilejson::Center::new(
-                self.center_longitude as f64,
-                self.center_latitude as f64,
-                self.center_zoom,
-            ),
+            bounds: self.get_bounds(),
+            center: self.get_center(),
         }
+    }
+
+    pub fn get_bounds(&self) -> tilejson::Bounds {
+        tilejson::Bounds::new(
+            self.min_longitude as f64,
+            self.min_latitude as f64,
+            self.max_longitude as f64,
+            self.max_latitude as f64,
+        )
+    }
+
+    pub fn get_center(&self) -> tilejson::Center {
+        tilejson::Center::new(
+            self.center_longitude as f64,
+            self.center_latitude as f64,
+            self.center_zoom,
+        )
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -67,6 +67,6 @@ mod tests {
         let client = reqwest::Client::builder().use_rustls_tls().build().unwrap();
         let backend = HttpBackend::try_from(client, TEST_URL).unwrap();
 
-        let _tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        AsyncPmTilesReader::try_from_source(backend).await.unwrap();
     }
 }

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,7 +1,3 @@
-use bytes::Bytes;
-
-use crate::{Compression, TileType};
-
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio", test))]
 pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
     if z == 0 {
@@ -13,12 +9,6 @@ pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
     let tile_id = hilbert_2d::u64::xy2h_discrete(x, y, z.into(), hilbert_2d::Variant::Hilbert);
 
     base_id + tile_id
-}
-
-pub struct Tile {
-    pub data: Bytes,
-    pub tile_type: TileType,
-    pub tile_compression: Compression,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* there is no point in returning type and compression with every `get_tile` -- PMTiles keeps this data in the header, so it is constant, and if the user needs it, they can get it directly. Returns `bytes` now.
* add `Entry::is_leaf` helper
* add `Header::get_bounds` and `Header::get_center` (tilejson structs)
* no need for `AsyncPmTilesReader<B: ...>` type - it has to be specified in the impl anyway
* no need for the `backend::read_initial_bytes` - it is only used once, has default implementation anyway. Inlined.
* inlined `read_directory_with_backend` - used once and tiny
* split up the `find_tile_entry` into two functions - I will need this later to add caching -- the root entry is permanently cached as part of the main struct, but the other ones are not, so needs a different code path.
* added `cargo test` for default features