### PR TITLE
Directory Caching trait

### DIFF
--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -9,7 +9,7 @@ use reqwest::{Client, IntoUrl};
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 use tokio::io::AsyncReadExt;
 
-use crate::cache::SearchResult;
+use crate::cache::DirCacheResult;
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 use crate::cache::{DirectoryCache, NoCache};
 use crate::directory::{DirEntry, Directory};
@@ -161,7 +161,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         let offset = (self.header.leaf_offset + entry.offset) as _;
 
         let entry = match self.cache.get_dir_entry(offset, tile_id) {
-            SearchResult::NotCached => {
+            DirCacheResult::NotCached => {
                 // Cache miss - read from backend
                 let length = entry.length as _;
                 let dir = self.read_directory(offset, length).await.ok()?;
@@ -169,8 +169,8 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
                 self.cache.insert_dir(offset, dir);
                 entry
             }
-            SearchResult::NotFound => None,
-            SearchResult::Found(entry) => Some(entry),
+            DirCacheResult::NotFound => None,
+            DirCacheResult::Found(entry) => Some(entry),
         };
 
         if let Some(ref entry) = entry {

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -220,7 +220,7 @@ impl AsyncPmTilesReader<HttpBackend, NoCache> {
     ///
     /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
     pub async fn new_with_url<U: IntoUrl>(client: Client, url: U) -> Result<Self, PmtError> {
-        Self::new_with_cached_url(client, url, NoCache).await
+        Self::new_with_cached_url(NoCache, client, url).await
     }
 }
 
@@ -230,9 +230,9 @@ impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<HttpBackend, C> {
     ///
     /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
     pub async fn new_with_cached_url<U: IntoUrl>(
+        cache: C,
         client: Client,
         url: U,
-        cache: C,
     ) -> Result<Self, Error> {
         let backend = HttpBackend::try_from(client, url)?;
 
@@ -246,7 +246,7 @@ impl AsyncPmTilesReader<MmapBackend, NoCache> {
     ///
     /// Fails if [p] does not exist or is an invalid archive.
     pub async fn new_with_path<P: AsRef<Path>>(path: P) -> Result<Self, PmtError> {
-        Self::new_with_cached_path(path, NoCache).await
+        Self::new_with_cached_path(NoCache, path).await
     }
 }
 
@@ -255,7 +255,7 @@ impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<MmapBackend, C> {
     /// Creates a new cached PMTiles reader from a file path using the async mmap backend.
     ///
     /// Fails if [p] does not exist or is an invalid archive.
-    pub async fn new_with_cached_path<P: AsRef<Path>>(path: P, cache: C) -> Result<Self, Error> {
+    pub async fn new_with_cached_path<P: AsRef<Path>>(cache: C, path: P) -> Result<Self, Error> {
         let backend = MmapBackend::try_from(path).await?;
 
         Self::try_from_cached_source(backend, cache).await

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -9,6 +9,9 @@ use reqwest::{Client, IntoUrl};
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 use tokio::io::AsyncReadExt;
 
+use crate::cache::SearchResult;
+#[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
+use crate::cache::{DirectoryCache, NoCache};
 use crate::directory::{Directory, Entry};
 use crate::error::PmtError;
 use crate::header::{HEADER_SIZE, MAX_INITIAL_BYTES};
@@ -19,17 +22,27 @@ use crate::mmap::MmapBackend;
 use crate::tile::tile_id;
 use crate::{Compression, Header};
 
-pub struct AsyncPmTilesReader<B> {
+pub struct AsyncPmTilesReader<B, C = NoCache> {
     backend: B,
+    cache: C,
     header: Header,
     root_directory: Directory,
 }
 
-impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
+impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B, NoCache> {
+    /// Creates a new cached reader from a specified source and validates the provided PMTiles archive is valid.
+    ///
+    /// Note: Prefer using new_with_* methods.
+    pub async fn try_from_source(backend: B) -> Result<Self, Error> {
+        Self::try_from_cached_source(backend, NoCache).await
+    }
+}
+
+impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTilesReader<B, C> {
     /// Creates a new reader from a specified source and validates the provided PMTiles archive is valid.
     ///
     /// Note: Prefer using new_with_* methods.
-    pub async fn try_from_source(backend: B) -> Result<Self, PmtError> {
+    pub async fn try_from_cached_source(backend: B, cache: C) -> Result<Self, PmtError> {
         // Read the first 127 and up to 16,384 bytes to ensure we can initialize the header and root directory.
         let mut initial_bytes = backend.read(0, MAX_INITIAL_BYTES).await?;
         if initial_bytes.len() < HEADER_SIZE {
@@ -47,6 +60,7 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
 
         Ok(Self {
             backend,
+            cache,
             header,
             root_directory,
         })
@@ -145,11 +159,21 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
         // the recursion is done as two functions because it is a bit cleaner,
         // and it allows directory to be cached later without cloning it first.
         let offset = (self.header.leaf_offset + entry.offset) as _;
-        let length = entry.length as _;
-        let dir = self.read_directory(offset, length).await.ok()?;
-        let entry = dir.find_tile_id(tile_id);
 
-        if let Some(entry) = entry {
+        let entry = match self.cache.get_dir_entry(offset, tile_id) {
+            SearchResult::NotCached => {
+                // Cache miss - read from backend
+                let length = entry.length as _;
+                let dir = self.read_directory(offset, length).await.ok()?;
+                let entry = dir.find_tile_id(tile_id).cloned();
+                self.cache.insert_dir(offset, dir);
+                entry
+            }
+            SearchResult::NotFound => None,
+            SearchResult::Found(entry) => Some(entry),
+        };
+
+        if let Some(ref entry) = entry {
             if entry.is_leaf() {
                 return if depth <= 4 {
                     self.find_entry_rec(tile_id, entry, depth + 1).await
@@ -159,7 +183,7 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
             }
         }
 
-        entry.cloned()
+        entry
     }
 
     async fn read_directory(&self, offset: usize, length: usize) -> Result<Directory, PmtError> {
@@ -191,26 +215,50 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
 }
 
 #[cfg(feature = "http-async")]
-impl AsyncPmTilesReader<HttpBackend> {
+impl AsyncPmTilesReader<HttpBackend, NoCache> {
     /// Creates a new PMTiles reader from a URL using the Reqwest backend.
     ///
     /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
     pub async fn new_with_url<U: IntoUrl>(client: Client, url: U) -> Result<Self, PmtError> {
+        Self::new_with_cached_url(client, url, NoCache).await
+    }
+}
+
+#[cfg(feature = "http-async")]
+impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<HttpBackend, C> {
+    /// Creates a new PMTiles reader with cache from a URL using the Reqwest backend.
+    ///
+    /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
+    pub async fn new_with_cached_url<U: IntoUrl>(
+        client: Client,
+        url: U,
+        cache: C,
+    ) -> Result<Self, Error> {
         let backend = HttpBackend::try_from(client, url)?;
 
-        Self::try_from_source(backend).await
+        Self::try_from_cached_source(backend, cache).await
     }
 }
 
 #[cfg(feature = "mmap-async-tokio")]
-impl AsyncPmTilesReader<MmapBackend> {
+impl AsyncPmTilesReader<MmapBackend, NoCache> {
     /// Creates a new PMTiles reader from a file path using the async mmap backend.
     ///
     /// Fails if [p] does not exist or is an invalid archive.
     pub async fn new_with_path<P: AsRef<Path>>(path: P) -> Result<Self, PmtError> {
+        Self::new_with_cached_path(path, NoCache).await
+    }
+}
+
+#[cfg(feature = "mmap-async-tokio")]
+impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<MmapBackend, C> {
+    /// Creates a new cached PMTiles reader from a file path using the async mmap backend.
+    ///
+    /// Fails if [p] does not exist or is an invalid archive.
+    pub async fn new_with_cached_path<P: AsRef<Path>>(path: P, cache: C) -> Result<Self, Error> {
         let backend = MmapBackend::try_from(path).await?;
 
-        Self::try_from_source(backend).await
+        Self::try_from_cached_source(backend, cache).await
     }
 }
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -30,7 +30,7 @@ pub struct AsyncPmTilesReader<B, C = NoCache> {
 }
 
 impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B, NoCache> {
-    /// Creates a new cached reader from a specified source and validates the provided PMTiles archive is valid.
+    /// Creates a new reader from a specified source and validates the provided PMTiles archive is valid.
     ///
     /// Note: Prefer using new_with_* methods.
     pub async fn try_from_source(backend: B) -> Result<Self, PmtError> {
@@ -39,7 +39,7 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B, NoCache> {
 }
 
 impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTilesReader<B, C> {
-    /// Creates a new reader from a specified source and validates the provided PMTiles archive is valid.
+    /// Creates a new cached reader from a specified source and validates the provided PMTiles archive is valid.
     ///
     /// Note: Prefer using new_with_* methods.
     pub async fn try_from_cached_source(backend: B, cache: C) -> Result<Self, PmtError> {

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -12,7 +12,7 @@ use tokio::io::AsyncReadExt;
 use crate::cache::SearchResult;
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 use crate::cache::{DirectoryCache, NoCache};
-use crate::directory::{Directory, Entry};
+use crate::directory::{DirEntry, Directory};
 use crate::error::PmtError;
 use crate::header::{HEADER_SIZE, MAX_INITIAL_BYTES};
 #[cfg(feature = "http-async")]
@@ -144,7 +144,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
     }
 
     /// Recursively locates a tile in the archive.
-    async fn find_tile_entry(&self, tile_id: u64) -> Option<Entry> {
+    async fn find_tile_entry(&self, tile_id: u64) -> Option<DirEntry> {
         let entry = self.root_directory.find_tile_id(tile_id)?;
         if entry.is_leaf() {
             self.find_entry_rec(tile_id, entry, 0).await
@@ -155,7 +155,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
     }
 
     #[async_recursion]
-    async fn find_entry_rec(&self, tile_id: u64, entry: &Entry, depth: u8) -> Option<Entry> {
+    async fn find_entry_rec(&self, tile_id: u64, entry: &DirEntry, depth: u8) -> Option<DirEntry> {
         // the recursion is done as two functions because it is a bit cleaner,
         // and it allows directory to be cached later without cloning it first.
         let offset = (self.header.leaf_offset + entry.offset) as _;

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -131,13 +131,13 @@ impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B> {
 
     /// Recursively locates a tile in the archive.
     async fn find_tile_entry(&self, tile_id: u64) -> Option<Entry> {
-        let entry = self.root_directory.find_tile_id(tile_id);
-        if let Some(entry) = entry {
-            if entry.is_leaf() {
-                return self.find_entry_rec(tile_id, entry, 0).await;
-            }
+        let entry = self.root_directory.find_tile_id(tile_id)?;
+        if entry.is_leaf() {
+            self.find_entry_rec(tile_id, entry, 0).await
+        } else {
+            entry
         }
-        entry.cloned()
+        .cloned()
     }
 
     #[async_recursion]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::directory::{Directory, Entry};
+use crate::directory::{DirEntry, Directory};
 
 pub enum SearchResult {
     NotCached,
     NotFound,
-    Found(Entry),
+    Found(DirEntry),
 }
 
-impl From<Option<&Entry>> for SearchResult {
-    fn from(entry: Option<&Entry>) -> Self {
+impl From<Option<&DirEntry>> for SearchResult {
+    fn from(entry: Option<&DirEntry>) -> Self {
         match entry {
             Some(entry) => SearchResult::Found(entry.clone()),
             None => SearchResult::NotFound,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::directory::{Directory, Entry};
+
+pub enum SearchResult {
+    NotCached,
+    NotFound,
+    Found(Entry),
+}
+
+impl From<Option<&Entry>> for SearchResult {
+    fn from(entry: Option<&Entry>) -> Self {
+        match entry {
+            Some(entry) => SearchResult::Found(entry.clone()),
+            None => SearchResult::NotFound,
+        }
+    }
+}
+
+/// A cache for PMTiles directories.
+pub trait DirectoryCache {
+    /// Get a directory from the cache, using the offset as a key.
+    fn get_dir_entry(&self, offset: usize, tile_id: u64) -> SearchResult;
+
+    /// Insert a directory into the cache, using the offset as a key.
+    /// Note that cache must be internally mutable.
+    fn insert_dir(&self, offset: usize, directory: Directory);
+}
+
+pub struct NoCache;
+
+impl DirectoryCache for NoCache {
+    #[inline]
+    fn get_dir_entry(&self, _offset: usize, _tile_id: u64) -> SearchResult {
+        SearchResult::NotCached
+    }
+
+    #[inline]
+    fn insert_dir(&self, _offset: usize, _directory: Directory) {}
+}
+
+/// A simple HashMap-based implementation of a PMTiles directory cache.
+#[derive(Default)]
+pub struct HashMapCache {
+    pub cache: Arc<Mutex<HashMap<usize, Directory>>>,
+}
+
+impl DirectoryCache for HashMapCache {
+    fn get_dir_entry(&self, offset: usize, tile_id: u64) -> SearchResult {
+        if let Some(dir) = self.cache.lock().unwrap().get(&offset) {
+            return dir.find_tile_id(tile_id).into();
+        }
+        SearchResult::NotCached
+    }
+
+    fn insert_dir(&self, offset: usize, directory: Directory) {
+        self.cache.lock().unwrap().insert(offset, directory);
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 
@@ -47,19 +47,19 @@ impl DirectoryCache for NoCache {
 /// A simple HashMap-based implementation of a PMTiles directory cache.
 #[derive(Default)]
 pub struct HashMapCache {
-    pub cache: Arc<Mutex<HashMap<usize, Directory>>>,
+    pub cache: Arc<RwLock<HashMap<usize, Directory>>>,
 }
 
 #[async_trait]
 impl DirectoryCache for HashMapCache {
     async fn get_dir_entry(&self, offset: usize, tile_id: u64) -> DirCacheResult {
-        if let Some(dir) = self.cache.lock().unwrap().get(&offset) {
+        if let Some(dir) = self.cache.read().unwrap().get(&offset) {
             return dir.find_tile_id(tile_id).into();
         }
         DirCacheResult::NotCached
     }
 
     async fn insert_dir(&self, offset: usize, directory: Directory) {
-        self.cache.lock().unwrap().insert(offset, directory);
+        self.cache.write().unwrap().insert(offset, directory);
     }
 }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -5,6 +5,7 @@ use varint_rs::VarintReader;
 
 use crate::error::PmtError;
 
+#[derive(Clone)]
 pub struct Directory {
     entries: Vec<DirEntry>,
 }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -6,7 +6,7 @@ use varint_rs::VarintReader;
 use crate::error::PmtError;
 
 pub struct Directory {
-    entries: Vec<Entry>,
+    entries: Vec<DirEntry>,
 }
 
 impl Debug for Directory {
@@ -17,7 +17,7 @@ impl Debug for Directory {
 
 impl Directory {
     #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
-    pub fn find_tile_id(&self, tile_id: u64) -> Option<&Entry> {
+    pub fn find_tile_id(&self, tile_id: u64) -> Option<&DirEntry> {
         match self.entries.binary_search_by(|e| e.tile_id.cmp(&tile_id)) {
             Ok(idx) => self.entries.get(idx),
             Err(next_id) => {
@@ -44,7 +44,7 @@ impl TryFrom<Bytes> for Directory {
         let mut buffer = buffer.reader();
         let n_entries = buffer.read_usize_varint()?;
 
-        let mut entries = vec![Entry::default(); n_entries];
+        let mut entries = vec![DirEntry::default(); n_entries];
 
         // Read tile IDs
         let mut next_tile_id = 0;
@@ -64,7 +64,7 @@ impl TryFrom<Bytes> for Directory {
         }
 
         // Read Offsets
-        let mut last_entry: Option<&Entry> = None;
+        let mut last_entry: Option<&DirEntry> = None;
         for entry in entries.iter_mut() {
             let offset = buffer.read_u64_varint()?;
             entry.offset = if offset == 0 {
@@ -81,7 +81,7 @@ impl TryFrom<Bytes> for Directory {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct Entry {
+pub struct DirEntry {
     pub(crate) tile_id: u64,
     pub(crate) offset: u64,
     pub(crate) length: u32,
@@ -89,7 +89,7 @@ pub struct Entry {
 }
 
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
-impl Entry {
+impl DirEntry {
     pub(crate) fn is_leaf(&self) -> bool {
         self.run_length == 0
     }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -5,7 +5,7 @@ use varint_rs::VarintReader;
 
 use crate::error::PmtError;
 
-pub(crate) struct Directory {
+pub struct Directory {
     entries: Vec<Entry>,
 }
 
@@ -81,7 +81,7 @@ impl TryFrom<Bytes> for Directory {
 }
 
 #[derive(Clone, Default, Debug)]
-pub(crate) struct Entry {
+pub struct Entry {
     pub(crate) tile_id: u64,
     pub(crate) offset: u64,
     pub(crate) length: u32,
@@ -90,7 +90,7 @@ pub(crate) struct Entry {
 
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 impl Entry {
-    pub fn is_leaf(&self) -> bool {
+    pub(crate) fn is_leaf(&self) -> bool {
         self.run_length == 0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod header;
 pub use crate::header::{Compression, Header, TileType};
 
 mod directory;
-pub use directory::{Directory, Entry};
+pub use directory::{DirEntry, Directory};
 
 mod error;
 pub use error::PmtError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ pub use error::PmtError;
 #[cfg(feature = "http-async")]
 pub use error::PmtHttpError;
 
-mod header;
-
 #[cfg(feature = "http-async")]
 pub mod http;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 #![forbid(unsafe_code)]
 
+mod tile;
+
+mod header;
 pub use crate::header::{Compression, Header, TileType};
 
 mod directory;
+pub use directory::{Directory, Entry};
 
 mod error;
 pub use error::PmtError;
@@ -19,7 +23,9 @@ pub mod mmap;
 
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 pub mod async_reader;
-pub mod tile;
+
+#[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
+pub mod cache;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
A cache implementation based on #23 (compare to that to see the diff) which adds a new `DirectoryCache` trait and a few helpers. `Directory` and `Entry` are now public, but neither have any public functions except for `find_tile_id` which cache should use while locking its internal state if needed.