### PR TITLE
Rename Error and HttpError, and move them to root

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 use bytes::{Buf, Bytes};
 use varint_rs::VarintReader;
 
-use crate::error::Error;
+use crate::error::PmtError;
 
 pub(crate) struct Directory {
     entries: Vec<Entry>,
@@ -38,9 +38,9 @@ impl Directory {
 }
 
 impl TryFrom<Bytes> for Directory {
-    type Error = Error;
+    type Error = PmtError;
 
-    fn try_from(buffer: Bytes) -> Result<Self, Error> {
+    fn try_from(buffer: Bytes) -> Result<Self, PmtError> {
         let mut buffer = buffer.reader();
         let n_entries = buffer.read_usize_varint()?;
 
@@ -68,7 +68,7 @@ impl TryFrom<Bytes> for Directory {
         for entry in entries.iter_mut() {
             let offset = buffer.read_u64_varint()?;
             entry.offset = if offset == 0 {
-                let e = last_entry.ok_or(Error::InvalidEntry)?;
+                let e = last_entry.ok_or(PmtError::InvalidEntry)?;
                 e.offset + e.length as u64
             } else {
                 offset - 1

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::string::FromUtf8Error;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub enum PmtError {
     #[error("Invalid magic number")]
     InvalidMagicNumber,
     #[error("Invalid PMTiles version")]
@@ -27,12 +27,12 @@ pub enum Error {
     UnableToOpenMmapFile,
     #[cfg(feature = "http-async")]
     #[error("{0}")]
-    Http(#[from] HttpError),
+    Http(#[from] PmtHttpError),
 }
 
 #[cfg(feature = "http-async")]
 #[derive(Debug, Error)]
-pub enum HttpError {
+pub enum PmtHttpError {
     #[error("Unexpected number of bytes returned [expected: {0}, received: {1}].")]
     UnexpectedNumberOfBytesReturned(usize, usize),
     #[error("Range requests unsupported")]
@@ -47,8 +47,8 @@ pub enum HttpError {
 
 // This is required because thiserror #[from] does not support two-level conversion.
 #[cfg(feature = "http-async")]
-impl From<reqwest::Error> for Error {
+impl From<reqwest::Error> for PmtError {
     fn from(e: reqwest::Error) -> Self {
-        Self::Http(HttpError::Http(e))
+        Self::Http(PmtHttpError::Http(e))
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -3,7 +3,7 @@ use std::panic::catch_unwind;
 
 use bytes::{Buf, Bytes};
 
-use crate::error::Error;
+use crate::error::PmtError;
 
 #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
 pub(crate) const MAX_INITIAL_BYTES: usize = 16_384;
@@ -59,7 +59,7 @@ impl Compression {
 }
 
 impl TryInto<Compression> for u8 {
-    type Error = Error;
+    type Error = PmtError;
 
     fn try_into(self) -> Result<Compression, Self::Error> {
         match self {
@@ -68,7 +68,7 @@ impl TryInto<Compression> for u8 {
             2 => Ok(Compression::Gzip),
             3 => Ok(Compression::Brotli),
             4 => Ok(Compression::Zstd),
-            _ => Err(Error::InvalidCompression),
+            _ => Err(PmtError::InvalidCompression),
         }
     }
 }
@@ -125,7 +125,7 @@ impl TileType {
 }
 
 impl TryInto<TileType> for u8 {
-    type Error = Error;
+    type Error = PmtError;
 
     fn try_into(self) -> Result<TileType, Self::Error> {
         match self {
@@ -134,7 +134,7 @@ impl TryInto<TileType> for u8 {
             2 => Ok(TileType::Png),
             3 => Ok(TileType::Jpeg),
             4 => Ok(TileType::Webp),
-            _ => Err(Error::InvalidTileType),
+            _ => Err(PmtError::InvalidTileType),
         }
     }
 }
@@ -147,15 +147,15 @@ impl Header {
         buf.get_i32_le() as f32 / 10_000_000.
     }
 
-    pub fn try_from_bytes(mut bytes: Bytes) -> Result<Self, Error> {
+    pub fn try_from_bytes(mut bytes: Bytes) -> Result<Self, PmtError> {
         let magic_bytes = bytes.split_to(V3_MAGIC.len());
 
         // Assert magic
         if magic_bytes != V3_MAGIC {
             return Err(if magic_bytes.starts_with(V2_MAGIC.as_bytes()) {
-                Error::UnsupportedPmTilesVersion
+                PmtError::UnsupportedPmTilesVersion
             } else {
-                Error::InvalidMagicNumber
+                PmtError::InvalidMagicNumber
             });
         }
 
@@ -189,7 +189,7 @@ impl Header {
                 center_latitude: Self::read_coordinate_part(&mut bytes),
             })
         })
-        .map_err(|_| Error::InvalidHeader)?
+        .map_err(|_| PmtError::InvalidHeader)?
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,12 @@
 pub use crate::header::{Compression, Header, TileType};
 
 mod directory;
-pub mod error;
+
+mod error;
+pub use error::PmtError;
+#[cfg(feature = "http-async")]
+pub use error::PmtHttpError;
+
 mod header;
 
 #[cfg(feature = "http-async")]

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -6,23 +6,23 @@ use bytes::{Buf, Bytes};
 use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt as _, AsyncOptions};
 
 use crate::async_reader::AsyncBackend;
-use crate::error::Error;
+use crate::error::PmtError;
 
 pub struct MmapBackend {
     file: AsyncMmapFile,
 }
 
 impl MmapBackend {
-    pub async fn try_from<P: AsRef<Path>>(p: P) -> Result<Self, Error> {
+    pub async fn try_from<P: AsRef<Path>>(p: P) -> Result<Self, PmtError> {
         Ok(Self {
             file: AsyncMmapFile::open_with_options(p, AsyncOptions::new().read(true))
                 .await
-                .map_err(|_| Error::UnableToOpenMmapFile)?,
+                .map_err(|_| PmtError::UnableToOpenMmapFile)?,
         })
     }
 }
 
-impl From<fmmap::error::Error> for Error {
+impl From<fmmap::error::Error> for PmtError {
     fn from(_: fmmap::error::Error) -> Self {
         Self::Reading(io::Error::from(io::ErrorKind::UnexpectedEof))
     }
@@ -30,17 +30,17 @@ impl From<fmmap::error::Error> for Error {
 
 #[async_trait]
 impl AsyncBackend for MmapBackend {
-    async fn read_exact(&self, offset: usize, length: usize) -> Result<Bytes, Error> {
+    async fn read_exact(&self, offset: usize, length: usize) -> Result<Bytes, PmtError> {
         if self.file.len() >= offset + length {
             Ok(self.file.reader(offset)?.copy_to_bytes(length))
         } else {
-            Err(Error::Reading(io::Error::from(
+            Err(PmtError::Reading(io::Error::from(
                 io::ErrorKind::UnexpectedEof,
             )))
         }
     }
 
-    async fn read(&self, offset: usize, length: usize) -> Result<Bytes, Error> {
+    async fn read(&self, offset: usize, length: usize) -> Result<Bytes, PmtError> {
         let reader = self.file.reader(offset)?;
 
         let read_length = length.min(reader.len());


### PR DESCRIPTION
Even clippy now suggests not to use `Error` name because it is becoming increasingly conflicting with other libs.  Renamed things to `PmtError` and `PmtHttpError`.  This will probably have merge conflicts with the other PRs - so just +1 and i will fix it after merge.