### PR TITLE
Add Directory::get_approx_byte_size and bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pmtiles"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>"]
 license = "MIT OR Apache-2.0"
 description = "Implementation of the PMTiles v3 spec with multiple sync and async backends."
 repository = "https://github.com/stadiamaps/pmtiles-rs"
 keywords = ["pmtiles", "gis", "geo"]
-rust-version = "1.61.0"
+rust-version = "1.68.2"
 categories = ["science::geo"]
 
 [features]

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -17,6 +17,7 @@ impl Debug for Directory {
 }
 
 impl Directory {
+    /// Find the directory entry for a given tile ID.
     #[cfg(any(feature = "http-async", feature = "mmap-async-tokio"))]
     #[must_use]
     pub fn find_tile_id(&self, tile_id: u64) -> Option<&DirEntry> {
@@ -36,6 +37,11 @@ impl Directory {
                 None
             }
         }
+    }
+
+    /// Get an estimated byte size of the directory object. Use this for cache eviction.
+    pub fn get_approx_byte_size(&self) -> usize {
+        self.entries.capacity() * std::mem::size_of::<DirEntry>()
     }
 }
 

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -40,6 +40,7 @@ impl Directory {
     }
 
     /// Get an estimated byte size of the directory object. Use this for cache eviction.
+    #[must_use]
     pub fn get_approx_byte_size(&self) -> usize {
         self.entries.capacity() * std::mem::size_of::<DirEntry>()
     }


### PR DESCRIPTION
For cache eviction purposes, it is important to know the size of the directory objects.  Also, I ran `cargo msrv` to figure out the minimal one.