### PR TITLE
Add AsyncReader::try_get_tile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>"]
 license = "MIT OR Apache-2.0"
@@ -39,7 +39,7 @@ async-trait = "0.1"
 bytes = "1"
 fmmap = { version = "0.3", default-features = false, optional = true }
 hilbert_2d = "1"
-reqwest = { version = "0.11", default-features = false, optional = true }
+reqwest = { version = "0.12.3", default-features = false, optional = true }
 rust-s3 = {  version = "0.33.0", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
@@ -51,7 +51,7 @@ varint-rs = "2"
 [dev-dependencies]
 flate2 = "1"
 fmmap = { version = "0.3", features = ["tokio-async"] }
-reqwest = { version = "0.11", features = ["rustls-tls-webpki-roots"] }
+reqwest = { version = "0.12.3", features = ["rustls-tls-webpki-roots"] }
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
 
 [package.metadata.docs.rs]

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,4 +47,6 @@ pub enum PmtError {
     #[cfg(feature = "__async-s3")]
     #[error(transparent)]
     S3(#[from] s3::error::S3Error),
+    #[error("Tile was not found in the PMTiles archive.")]
+    TileNotFound,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,4 @@ pub enum PmtError {
     #[cfg(feature = "__async-s3")]
     #[error(transparent)]
     S3(#[from] s3::error::S3Error),
-    #[error("Tile was not found in the PMTiles archive.")]
-    TileNotFound,
 }


### PR DESCRIPTION
* Exposes the error when fetching a tile (to ensure we can distinguish between missing tiles and upstream errors).
* Adds a `TileNotFound` error case.
* Bumps version to 0.8.0.