### PR TITLE
Use built-in async recursion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Implementation of the PMTiles v3 spec with multiple sync and async backends."
 repository = "https://github.com/stadiamaps/pmtiles-rs"
 keywords = ["pmtiles", "gis", "geo"]
-rust-version = "1.75.0"
+rust-version = "1.77.0"
 categories = ["science::geo"]
 
 [features]
@@ -34,7 +34,6 @@ __async-s3-rustls = ["rust-s3?/tokio-rustls-tls"]
 [dependencies]
 # TODO: determine how we want to handle compression in async & sync environments
 async-compression = { version = "0.4", features = ["gzip", "zstd", "brotli"] }
-async-recursion = "1"
 bytes = "1"
 fmmap = { version = "0.3", default-features = false, optional = true }
 hilbert_2d = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -4,7 +4,6 @@
 
 use std::future::Future;
 
-use async_recursion::async_recursion;
 use bytes::Bytes;
 #[cfg(feature = "__async")]
 use tokio::io::AsyncReadExt;
@@ -149,7 +148,6 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         Ok(entry.cloned())
     }
 
-    #[async_recursion]
     async fn find_entry_rec(
         &self,
         tile_id: u64,
@@ -176,7 +174,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         if let Some(ref entry) = entry {
             if entry.is_leaf() {
                 return if depth <= 4 {
-                    self.find_entry_rec(tile_id, entry, depth + 1).await
+                    Box::pin(self.find_entry_rec(tile_id, entry, depth + 1)).await
                 } else {
                     Ok(None)
                 };


### PR DESCRIPTION
Requires Rust v1.77.0

I think this shouldn't be merged just yet because most github runners don't have v1.77 yet...  Maybe when v1.78 or v1.79 come out?