### PR TITLE
Extract zstd into a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio-async"]
 s3-async-native = ["__async-s3", "__async-s3-nativetls"]
 s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
+zstd = [ "async-compression/zstd" ]
 
 # Forward some of the common features to reqwest dependency
 reqwest-default = ["reqwest?/default"]
@@ -33,7 +34,7 @@ __async-s3-rustls = ["rust-s3?/tokio-rustls-tls"]
 
 [dependencies]
 # TODO: determine how we want to handle compression in async & sync environments
-async-compression = { version = "0.4", features = ["gzip", "zstd", "brotli"] }
+async-compression = { version = "0.4", features = ["gzip", "brotli"] }
 async-recursion = "1"
 bytes = "1"
 fmmap = { version = "0.3", default-features = false, optional = true }


### PR DESCRIPTION
Hey, I'm interested in getting this lib to work for wasm targets. So let's start with the bare minimum of getting this to compile for wasm without any features enabled. The only real obstacle here was the `zstd` feature of `async-compression` which drew in some zstd binding rust crate. Moving this around gives us a starting point to get the rest to run on wasm as well.

If you want to have it enabled by default, we can put the `zstd` feature into the default features. Just let me know!