### PR TITLE
Add AWS S3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       - run: just test-all
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          features: "http-async,mmap-async-tokio,tilejson,s3-async-native,aws-s3-async"
 
   msrv:
     name: Test MSRV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
 
@@ -23,17 +24,7 @@ jobs:
           rustc --version
           cargo --version
           rustup --version
-      - run: cargo check
-      - run: rustup component add clippy rustfmt
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo test --all-targets --all-features
-      - run: cargo test --features http-async
-      - run: cargo test --features mmap-async-tokio
-      - run: cargo test --features tilejson
-      - run: cargo test --features s3-async-native
-      - run: cargo test --features s3-async-rustls
-      - run: cargo test
+      - run: just test-all
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
 
@@ -42,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
       - uses: Swatinem/rust-cache@v2
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: Read crate metadata
@@ -51,10 +43,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.metadata.outputs.rust-version }}
-      - run: cargo test --all-targets --all-features
-      - run: cargo test --features http-async
-      - run: cargo test --features mmap-async-tokio
-      - run: cargo test --features tilejson
-      - run: cargo test --features s3-async-native
-      - run: cargo test --features s3-async-rustls
-      - run: cargo test
+      - run: just test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
-          features: "http-async,mmap-async-tokio,tilejson,s3-async-native,aws-s3-async"
+          feature-group: only-explicit-features
+          features: "http-async,mmap-async-tokio,tilejson,s3-async-rustls,aws-s3-async"
 
   msrv:
     name: Test MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>"]
 license = "MIT OR Apache-2.0"
@@ -16,6 +16,7 @@ http-async = ["__async", "dep:reqwest"]
 mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio-async"]
 s3-async-native = ["__async-s3", "__async-s3-nativetls"]
 s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
+aws-s3-async = ["__async-aws-s3"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
 
 # Forward some of the common features to reqwest dependency
@@ -30,9 +31,11 @@ __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]
 __async-s3-nativetls = ["rust-s3?/tokio-native-tls"]
 __async-s3-rustls = ["rust-s3?/tokio-rustls-tls"]
+__async-aws-s3 = ["__async", "dep:aws-sdk-s3"]
 
 [dependencies]
 # TODO: determine how we want to handle compression in async & sync environments
+aws-sdk-s3 = { version = "1.49.0", optional = true }
 async-compression = { version = "0.4", features = ["gzip"] }
 bytes = "1"
 fmmap = { version = "0.3", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ reqwest-rustls-tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 # Internal features, do not use
 __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]
-__async-s3-nativetls = ["rust-s3?/tokio-native-tls"]
+__async-s3-nativetls = ["rust-s3?/use-tokio-native-tls"]
 __async-s3-rustls = ["rust-s3?/tokio-rustls-tls"]
 __async-aws-s3 = ["__async", "dep:aws-sdk-s3"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Implementation of the PMTiles v3 spec with multiple sync and async backends."
 repository = "https://github.com/stadiamaps/pmtiles-rs"
 keywords = ["pmtiles", "gis", "geo"]
-rust-version = "1.77.0"
+rust-version = "1.78.0"
 categories = ["science::geo"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ bytes = "1"
 fmmap = { version = "0.3", default-features = false, optional = true }
 hilbert_2d = "1"
 reqwest = { version = "0.12.4", default-features = false, optional = true }
-rust-s3 = { version = "0.33.0", optional = true, default-features = false, features = ["fail-on-err"] }
+rust-s3 = { version = "0.35.1", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Implementation of the PMTiles v3 spec with multiple sync and async backends."
 repository = "https://github.com/stadiamaps/pmtiles-rs"
 keywords = ["pmtiles", "gis", "geo"]
-rust-version = "1.78.0"
+rust-version = "1.81.0"
 categories = ["science::geo"]
 
 [features]

--- a/justfile
+++ b/justfile
@@ -3,31 +3,41 @@
 @_default:
     just --list --unsorted
 
+check:
+    cargo check
+
+_add_tools:
+    rustup component add clippy rustfmt
+
 # Run all tests
 test:
     # These are the same tests that are run on CI. Eventually CI should just call into justfile
-    cargo check
-    rustup component add clippy rustfmt
-    cargo fmt --all -- --check
-    cargo clippy --all-targets --all-features -- -D warnings
     cargo test --all-targets --all-features
     cargo test --features http-async
     cargo test --features mmap-async-tokio
     cargo test --features tilejson
     cargo test --features s3-async-native
     cargo test --features s3-async-rustls
+    cargo test --features aws-s3-async
     cargo test
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+# Run all tests and checks
+test-all: check fmt clippy
 
 # Run cargo fmt and cargo clippy
 lint: fmt clippy
 
 # Run cargo fmt
-fmt:
+fmt: _add_tools
+    cargo fmt --all -- --check
+
+# Run cargo fmt using Rust nightly
+fmt-nightly:
     cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
 
 # Run cargo clippy
-clippy:
+clippy: _add_tools
     cargo clippy --workspace --all-targets --all-features --bins --tests --lib --benches -- -D warnings
 
 # Build and open code documentation

--- a/justfile
+++ b/justfile
@@ -37,12 +37,12 @@ fmt-nightly:
 
 # Run cargo clippy
 clippy: _add_tools
-    cargo clippy --features http-async
-    cargo clippy --features mmap-async-tokio
-    cargo clippy --features tilejson
-    cargo clippy --features s3-async-native
-    cargo clippy --features s3-async-rustls
-    cargo clippy --features aws-s3-async
+    cargo clippy --workspace --all-targets --features http-async
+    cargo clippy --workspace --all-targets --features mmap-async-tokio
+    cargo clippy --workspace --all-targets --features tilejson
+    cargo clippy --workspace --all-targets --features s3-async-native
+    cargo clippy --workspace --all-targets --features s3-async-rustls
+    cargo clippy --workspace --all-targets --features aws-s3-async
 
 # Build and open code documentation
 docs:

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@
 @_default:
     just --list --unsorted
 
+# Run cargo check
 check:
     cargo check
 
@@ -11,7 +12,6 @@ _add_tools:
 
 # Run all tests
 test:
-    # These are the same tests that are run on CI. Eventually CI should just call into justfile
     cargo test --all-targets --all-features
     cargo test --features http-async
     cargo test --features mmap-async-tokio

--- a/justfile
+++ b/justfile
@@ -12,7 +12,6 @@ _add_tools:
 
 # Run all tests
 test:
-    cargo test --all-targets --all-features
     cargo test --features http-async
     cargo test --features mmap-async-tokio
     cargo test --features tilejson
@@ -38,7 +37,12 @@ fmt-nightly:
 
 # Run cargo clippy
 clippy: _add_tools
-    cargo clippy --workspace --all-targets --all-features --bins --tests --lib --benches -- -D warnings
+    cargo clippy --features http-async
+    cargo clippy --features mmap-async-tokio
+    cargo clippy --features tilejson
+    cargo clippy --features s3-async-native
+    cargo clippy --features s3-async-rustls
+    cargo clippy --features aws-s3-async
 
 # Build and open code documentation
 docs:

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -215,16 +215,25 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
 pub trait AsyncBackend {
     /// Reads exactly `length` bytes starting at `offset`
-    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
-        let data = self.read(offset, length).await?;
+    fn read_exact(
+        &self,
+        offset: usize,
+        length: usize,
+    ) -> impl Future<Output = PmtResult<Bytes>> + Send
+    where
+        Self: Sync,
+    {
+        async move {
+            let data = self.read(offset, length).await?;
 
-        if data.len() == length {
-            Ok(data)
-        } else {
-            Err(PmtError::UnexpectedNumberOfBytesReturned(
-                length,
-                data.len(),
-            ))
+            if data.len() == length {
+                Ok(data)
+            } else {
+                Err(PmtError::UnexpectedNumberOfBytesReturned(
+                    length,
+                    data.len(),
+                ))
+            }
         }
     }
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -215,16 +215,18 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
 pub trait AsyncBackend {
     /// Reads exactly `length` bytes starting at `offset`
-    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
-        let data = self.read(offset, length).await?;
+    fn read_exact(&self, offset: usize, length: usize) -> impl Future<Output = PmtResult<Bytes>> {
+        async move {
+            let data = self.read(offset, length).await?;
 
-        if data.len() == length {
-            Ok(data)
-        } else {
-            Err(PmtError::UnexpectedNumberOfBytesReturned(
-                length,
-                data.len(),
-            ))
+            if data.len() == length {
+                Ok(data)
+            } else {
+                Err(PmtError::UnexpectedNumberOfBytesReturned(
+                    length,
+                    data.len(),
+                ))
+            }
         }
     }
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -215,18 +215,16 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
 pub trait AsyncBackend {
     /// Reads exactly `length` bytes starting at `offset`
-    fn read_exact(&self, offset: usize, length: usize) -> impl Future<Output = PmtResult<Bytes>> {
-        async move {
-            let data = self.read(offset, length).await?;
+    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+        let data = self.read(offset, length).await?;
 
-            if data.len() == length {
-                Ok(data)
-            } else {
-                Err(PmtError::UnexpectedNumberOfBytesReturned(
-                    length,
-                    data.len(),
-                ))
-            }
+        if data.len() == length {
+            Ok(data)
+        } else {
+            Err(PmtError::UnexpectedNumberOfBytesReturned(
+                length,
+                data.len(),
+            ))
         }
     }
 

--- a/src/backend_aws_s3.rs
+++ b/src/backend_aws_s3.rs
@@ -1,0 +1,89 @@
+use crate::{
+    async_reader::{AsyncBackend, AsyncPmTilesReader},
+    cache::{DirectoryCache, NoCache},
+    PmtError, PmtResult,
+};
+use aws_sdk_s3::Client;
+use bytes::Bytes;
+
+impl AsyncPmTilesReader<AwsS3Backend, NoCache> {
+    /// Creates a new `PMTiles` reader from a client, bucket and key to the
+    /// archive using the `aws-sdk-s3` backend.
+    ///
+    /// Fails if the [bucket] or [key] does not exist or is an invalid
+    /// archive.
+    /// (Note: S3 requests are made to validate it.)
+    pub async fn new_with_client_bucket_and_path(
+        client: Client,
+        bucket: String,
+        key: String,
+    ) -> PmtResult<Self> {
+        Self::new_with_cached_client_bucket_and_path(NoCache, client, bucket, key).await
+    }
+}
+
+impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<AwsS3Backend, C> {
+    /// Creates a new `PMTiles` reader from a client, bucket and key to the
+    /// archive using the `aws-sdk-s3` backend. Caches using the designated
+    /// [cache].
+    ///
+    /// Fails if the [bucket] or [key] does not exist or is an invalid
+    /// archive.
+    /// (Note: S3 requests are made to validate it.)
+    pub async fn new_with_cached_client_bucket_and_path(
+        cache: C,
+        client: Client,
+        bucket: String,
+        key: String,
+    ) -> PmtResult<Self> {
+        let backend = AwsS3Backend::from(client, bucket, key);
+
+        Self::try_from_cached_source(backend, cache).await
+    }
+}
+
+pub struct AwsS3Backend {
+    client: Client,
+    bucket: String,
+    key: String,
+}
+
+impl AwsS3Backend {
+    #[must_use]
+    pub fn from(client: Client, bucket: String, key: String) -> Self {
+        Self {
+            client,
+            bucket,
+            key,
+        }
+    }
+}
+
+impl AsyncBackend for AwsS3Backend {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+        let range_end = offset + length - 1;
+        let range = format!("bytes={offset}-{range_end}");
+
+        let obj = self
+            .client
+            .get_object()
+            .bucket(self.bucket.clone())
+            .key(self.key.clone())
+            .range(range)
+            .send()
+            .await?;
+
+        let response_bytes = obj
+            .body
+            .collect()
+            .await
+            .map_err(|e| PmtError::Reading(e.into()))?
+            .into_bytes();
+
+        if response_bytes.len() > length {
+            Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
+        } else {
+            Ok(response_bytes)
+        }
+    }
+}

--- a/src/backend_http.rs
+++ b/src/backend_http.rs
@@ -46,19 +46,6 @@ impl HttpBackend {
 }
 
 impl AsyncBackend for HttpBackend {
-    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
-        let data = self.read(offset, length).await?;
-
-        if data.len() == length {
-            Ok(data)
-        } else {
-            Err(PmtError::UnexpectedNumberOfBytesReturned(
-                length,
-                data.len(),
-            ))
-        }
-    }
-
     async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
         let end = offset + length - 1;
         let range = format!("bytes={offset}-{end}");

--- a/src/backend_s3.rs
+++ b/src/backend_s3.rs
@@ -1,10 +1,12 @@
 use bytes::Bytes;
 use s3::Bucket;
 
-use crate::async_reader::{AsyncBackend, AsyncPmTilesReader};
-use crate::cache::{DirectoryCache, NoCache};
-use crate::error::PmtError::{ResponseBodyTooLong, UnexpectedNumberOfBytesReturned};
-use crate::PmtResult;
+use crate::{
+    async_reader::{AsyncBackend, AsyncPmTilesReader},
+    cache::{DirectoryCache, NoCache},
+    error::PmtError::ResponseBodyTooLong,
+    PmtResult,
+};
 
 impl AsyncPmTilesReader<S3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a bucket and path to the
@@ -61,7 +63,7 @@ impl AsyncBackend for S3Backend {
         if response_bytes.len() > length {
             Err(ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(response_bytes)
+            Ok(response_bytes.clone())
         }
     }
 }

--- a/src/backend_s3.rs
+++ b/src/backend_s3.rs
@@ -7,18 +7,21 @@ use crate::error::PmtError::{ResponseBodyTooLong, UnexpectedNumberOfBytesReturne
 use crate::PmtResult;
 
 impl AsyncPmTilesReader<S3Backend, NoCache> {
-    /// Creates a new `PMTiles` reader from a URL using the Reqwest backend.
+    /// Creates a new `PMTiles` reader from a bucket and path to the
+    /// archive using the `rust-s3` backend.
     ///
-    /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
+    /// Fails if [bucket] or [path] does not exist or is an invalid archive. (Note: S3 requests are made to validate it.)
     pub async fn new_with_bucket_path(bucket: Bucket, path: String) -> PmtResult<Self> {
         Self::new_with_cached_bucket_path(NoCache, bucket, path).await
     }
 }
 
 impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<S3Backend, C> {
-    /// Creates a new `PMTiles` reader with cache from a URL using the Reqwest backend.
+    /// Creates a new `PMTiles` reader from a bucket and path to the
+    /// archive using the `rust-s3` backend with a given [cache] backend.
     ///
-    /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
+    /// Fails if [bucket] or [path] does not exist or is an invalid archive. (Note: S3 requests are made to validate it.)
+    /// Creates a new `PMTiles` reader with cache from a URL using the Reqwest backend.
     pub async fn new_with_cached_bucket_path(
         cache: C,
         bucket: Bucket,
@@ -43,16 +46,6 @@ impl S3Backend {
 }
 
 impl AsyncBackend for S3Backend {
-    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
-        let data = self.read(offset, length).await?;
-
-        if data.len() == length {
-            Ok(data)
-        } else {
-            Err(UnexpectedNumberOfBytesReturned(length, data.len()))
-        }
-    }
-
     async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
         let response = self
             .bucket
@@ -68,7 +61,7 @@ impl AsyncBackend for S3Backend {
         if response_bytes.len() > length {
             Err(ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(response_bytes.clone())
+            Ok(response_bytes)
         }
     }
 }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -41,7 +41,7 @@ impl Directory {
     /// Get an estimated byte size of the directory object. Use this for cache eviction.
     #[must_use]
     pub fn get_approx_byte_size(&self) -> usize {
-        self.entries.capacity() * size_of::<DirEntry>()
+        self.entries.capacity() * std::mem::size_of::<DirEntry>()
     }
 }
 

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -41,7 +41,7 @@ impl Directory {
     /// Get an estimated byte size of the directory object. Use this for cache eviction.
     #[must_use]
     pub fn get_approx_byte_size(&self) -> usize {
-        self.entries.capacity() * std::mem::size_of::<DirEntry>()
+        self.entries.capacity() * size_of::<DirEntry>()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,11 @@ pub enum PmtError {
     #[cfg(feature = "http-async")]
     #[error("Range requests unsupported")]
     RangeRequestsUnsupported,
-    #[cfg(any(feature = "http-async", feature = "__async-s3"))]
+    #[cfg(any(
+        feature = "http-async",
+        feature = "__async-s3",
+        feature = "__async-aws-s3"
+    ))]
     #[error("HTTP response body is too long, Response {0}B > requested {1}B")]
     ResponseBodyTooLong(usize, usize),
     #[cfg(feature = "http-async")]
@@ -50,4 +54,9 @@ pub enum PmtError {
     #[cfg(feature = "__async-s3")]
     #[error(transparent)]
     S3(#[from] s3::error::S3Error),
+    #[cfg(feature = "__async-aws-s3")]
+    #[error(transparent)]
+    AwsS3Request(
+        #[from] aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+    ),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,6 @@ pub enum PmtError {
     #[cfg(feature = "mmap-async-tokio")]
     #[error("Unable to open mmap file")]
     UnableToOpenMmapFile,
-    #[cfg(any(feature = "http-async", feature = "__async-s3"))]
     #[error("Unexpected number of bytes returned [expected: {0}, received: {1}].")]
     UnexpectedNumberOfBytesReturned(usize, usize),
     #[cfg(feature = "http-async")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ mod header;
 #[cfg(feature = "__async")]
 mod tile;
 
+#[cfg(feature = "aws-s3-async")]
+pub use backend_aws_s3::AwsS3Backend;
 #[cfg(feature = "http-async")]
 pub use backend_http::HttpBackend;
 #[cfg(feature = "mmap-async-tokio")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "__async")]
 pub mod async_reader;
+#[cfg(feature = "__async-aws-s3")]
+mod backend_aws_s3;
 #[cfg(feature = "http-async")]
 mod backend_http;
 #[cfg(feature = "mmap-async-tokio")]
@@ -27,6 +29,8 @@ pub use error::{PmtError, PmtResult};
 pub use header::{Compression, Header, TileType};
 //
 // Re-export crates exposed in our API to simplify dependency management
+#[cfg(feature = "__async-aws-s3")]
+pub use aws_sdk_s3;
 #[cfg(feature = "http-async")]
 pub use reqwest;
 #[cfg(feature = "__async-s3")]


### PR DESCRIPTION
The `rust-s3` crate has a few issues, specifically a credentials refresh that is:

1) Unconditional (even if credentials are static)
2) Uses a ReadWrite lock that fails disturbingly often in production, causing unrecoverable errors.

This adds a backend based on the official AWS SDK, so people can choose that if they wish.