### PR TITLE
fix(perf): optimize the aws error size by boxing it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/backend_aws_s3.rs
+++ b/src/backend_aws_s3.rs
@@ -71,7 +71,8 @@ impl AsyncBackend for AwsS3Backend {
             .key(self.key.clone())
             .range(range)
             .send()
-            .await?;
+            .await
+            .map_err(Box::new)?;
 
         let response_bytes = obj
             .body

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,6 @@ pub enum PmtError {
     #[cfg(feature = "__async-aws-s3")]
     #[error(transparent)]
     AwsS3Request(
-        #[from] aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+        #[from] Box<aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>>,
     ),
 }


### PR DESCRIPTION
this PR boxes `aws_sdk_s3::error::SdkError` which is rougly 400 bytes.
Afterwards, the Error-variant is behind a pointer => ~8B (plus maybe a bit for variant-decision, but that could also be pointer-compressed away). In any case lower than the 20B of other variants.

This fixes [result_large_err](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err) for upstream code. (or for this library ^^)
The Rationale applies here as well imo.

>  A Result is at least as large as the Err-variant. While we expect that variant to be seldom used, the compiler needs to reserve and move that much memory every single time. Furthermore, errors are often simply passed up the call-stack, making use of the ?-operator and its type-conversion mechanics. If the Err-variant further up the call-stack stores the Err-variant in question (as library code often does), it itself needs to be at least as large, propagating the problem.

I can run benchmarks if needed, but I don't think this warrents them.