### PR TITLE
chore: remove rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,0 @@
-## These should be enabled in the future, but for now its a manual step to simplify usage.
-## Use cargo nightly for these:
-####  cargo +nightly fmt
-#imports_granularity = "Module"
-#group_imports = "StdExternalCrate"


### PR DESCRIPTION
This file has been integrated into the justfile.
https://github.com/stadiamaps/pmtiles-rs/blob/beb00f8ce7e6e086f81293cf49be6cfa2fe86a77/justfile#L56