### PR TITLE
chore: docs, cleanups, justfile updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with: { tool: 'just,cargo-llvm-cov' }
-      - uses: actions/checkout@v4
       - if: github.event_name == 'release'
         name: Ensure this crate has not yet been published (on release)
         run: just check-if-published
@@ -49,15 +49,15 @@ jobs:
     name: Test MSRV
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with: { tool: just }
-      - uses: actions/checkout@v4
       - name: Read MSRV
         id: msrv
-        run: echo "value=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
-      - name: Install Rust
+        run: echo "value=$(just get-msrv)" >> $GITHUB_OUTPUT
+      - name: Install MSRV Rust ${{ steps.msrv.outputs.value }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.msrv.outputs.value }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -43,8 +43,8 @@ __async-aws-s3 = ["__async", "dep:aws-sdk-s3"]
 
 [dependencies]
 # TODO: determine how we want to handle compression in async & sync environments
-aws-sdk-s3 = { version = "1.49.0", optional = true }
 async-compression = { version = "0.4", features = ["gzip"] }
+aws-sdk-s3 = { version = "1.49.0", optional = true }
 bytes = "1"
 fmmap = { version = "0.4", default-features = false, optional = true }
 hilbert_2d = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["science::geo"]
 
 [features]
 default = []
+aws-s3-async = ["__async-aws-s3"]
 http-async = ["__async", "dep:reqwest"]
 mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio"]
 s3-async-native = ["__async-s3", "__async-s3-nativetls"]
 s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
-aws-s3-async = ["__async-aws-s3"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
 
 # Forward some of the common features to reqwest dependency
@@ -26,7 +26,15 @@ reqwest-rustls-tls = ["reqwest?/rustls-tls"]
 reqwest-rustls-tls-native-roots = ["reqwest?/rustls-tls-native-roots"]
 reqwest-rustls-tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 
-# Internal features, do not use
+#### These features are for the internal usage only
+# This is a list of features we use in docs.rs and other places where we want everything
+__all_non_conflicting = [
+    "aws-s3-async",
+    "http-async",
+    "mmap-async-tokio",
+    "s3-async-rustls",
+    "tilejson",
+]
 __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]
 __async-s3-nativetls = ["rust-s3?/use-tokio-native-tls"]
@@ -56,7 +64,7 @@ reqwest = { version = "0.12.4", features = ["rustls-tls-webpki-roots"] }
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["__all_non_conflicting"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PMTiles (for Rust)
+# `PMTiles` (for Rust)
 
 [![GitHub](https://img.shields.io/badge/github-stadiamaps/pmtiles--rs-8da0cb?logo=github)](https://github.com/stadiamaps/pmtiles-rs)
 [![crates.io version](https://img.shields.io/crates/v/pmtiles.svg)](https://crates.io/crates/pmtiles)
@@ -12,7 +12,7 @@ originally created by Brandon Liu for Protomaps.
 
 ## Features
 
-- Opening and validating PMTile archives
+- Opening and validating `PMTile` archives
 - Querying tiles
 - Backends supported:
   - Async `mmap` (Tokio) for local files
@@ -22,7 +22,7 @@ originally created by Brandon Liu for Protomaps.
 ## Plans & TODOs
 
 - [ ] Documentation and example code
-- [ ] Support writing and conversion to and from MBTiles + `x/y/z`
+- [ ] Support writing and conversion to and from `MBTiles` + `x/y/z`
 - [ ] Support additional backends (sync `mmap` and `http` at least)
 - [ ] Support additional async styles (e.g., `async-std`)
 
@@ -30,7 +30,7 @@ PRs welcome!
 
 ## Usage examples
 
-### Reading from a local PMTiles file
+### Reading from a local `PMTiles` file
 
 ```rust,no_run
 use bytes::Bytes;
@@ -46,7 +46,7 @@ async fn get_tile(z: u8, x: u64, y: u64) -> Option<Bytes> {
 
 ### Reading from a URL with a simple directory cache
 
-This example uses a simple hashmap-based cache to optimize reads from a PMTiles source. The same caching is available for all other methods.  Note that `HashMapCache` is a rudimentary cache without eviction. You may want to build a more sophisticated cache for production use by implementing the `DirectoryCache` trait.
+This example uses a simple hashmap-based cache to optimize reads from a `PMTiles` source. The same caching is available for all other methods.  Note that `HashMapCache` is a rudimentary cache without eviction. You may want to build a more sophisticated cache for production use by implementing the `DirectoryCache` trait.
 
 ```rust,no_run
 use bytes::Bytes;
@@ -106,4 +106,4 @@ additional terms or conditions.
 
 ## Test Data License
 
-Some PMTile fixtures copied from official [PMTiles repository](https://github.com/protomaps/PMTiles/commit/257b41dd0497e05d1d686aa92ce2f742b6251644).
+Some `PMTile` fixtures copied from official [PMTiles repository](https://github.com/protomaps/PMTiles/commit/257b41dd0497e05d1d686aa92ce2f742b6251644).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,60 @@ originally created by Brandon Liu for Protomaps.
 
 PRs welcome!
 
+## Usage examples
+
+### Reading from a local PMTiles file
+
+```rust,no_run
+use bytes::Bytes;
+use pmtiles::async_reader::AsyncPmTilesReader;
+
+async fn get_tile(z: u8, x: u64, y: u64) -> Option<Bytes> {
+  let file = "example.pmtiles";
+  // Use `new_with_cached_path` for better performance
+  let reader = AsyncPmTilesReader::new_with_path(file).await.unwrap();
+  reader.get_tile(z, x, y).await.unwrap()
+}
+```
+
+### Reading from a URL with a simple directory cache
+
+This example uses a simple hashmap-based cache to optimize reads from a PMTiles source. The same caching is available for all other methods.  Note that `HashMapCache` is a rudimentary cache without eviction. You may want to build a more sophisticated cache for production use by implementing the `DirectoryCache` trait.
+
+```rust,no_run
+use bytes::Bytes;
+use pmtiles::async_reader::AsyncPmTilesReader;
+use pmtiles::cache::HashMapCache;
+use pmtiles::reqwest::Client;  // Re-exported Reqwest crate
+
+async fn get_tile(z: u8, x: u64, y: u64) -> Option<Bytes> {
+  let cache = HashMapCache::default();
+  let client = Client::builder().use_rustls_tls().build().unwrap();
+  let url = "https://protomaps.github.io/PMTiles/protomaps(vector)ODbL_firenze.pmtiles";
+  let reader = AsyncPmTilesReader::new_with_cached_url(cache, client, url).await.unwrap();
+  reader.get_tile(z, x, y).await.unwrap()
+}
+```
+
+### Reading from an S3 bucket with a directory cache
+
+AWS client configuration is fairly none-trivial to document here. See AWS SDK [documentation](https://crates.io/crates/aws-sdk-s3) for more details.
+
+```rust,no_run
+use bytes::Bytes;
+use pmtiles::async_reader::AsyncPmTilesReader;
+use pmtiles::aws_sdk_s3::Client; // Re-exported AWS SDK S3 client
+use pmtiles::cache::HashMapCache;
+
+async fn get_tile(client: Client, z: u8, x: u64, y: u64) -> Option<Bytes> {
+  let cache = HashMapCache::default();
+  let bucket = "https://s3.example.com".to_string();
+  let key = "example.pmtiles".to_string();
+  let reader = AsyncPmTilesReader::new_with_cached_client_bucket_and_path(cache, client, bucket, key).await.unwrap();
+  reader.get_tile(z, x, y).await.unwrap()
+}
+```
+
 ## Development
 
 * This project is easier to develop with [just](https://github.com/casey/just#readme), a modern alternative to `make`.

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ update:
 
 # Find unused dependencies. Install it with `cargo install cargo-udeps`
 udeps:
-    cargo +nightly udeps --all-targets --workspace
+    cargo +nightly udeps --all-targets --workspace --features __all_non_conflicting
 
 # Check semver compatibility with prior published version. Install it with `cargo install cargo-semver-checks`
 semver *ARGS:
@@ -28,7 +28,7 @@ semver *ARGS:
 
 # Find the minimum supported Rust version (MSRV) using cargo-msrv extension, and update Cargo.toml
 msrv:
-    cargo msrv find --write-msrv --ignore-lockfile
+    cargo msrv find --write-msrv --ignore-lockfile --features __all_non_conflicting
 
 # Get the minimum supported Rust version (MSRV) for the crate
 get-msrv: (get-crate-field "rust_version")
@@ -39,12 +39,8 @@ get-crate-field field package=CRATE_NAME:
 
 # Run cargo clippy to lint the code
 clippy: _add_tools
-    cargo clippy --workspace --all-targets --features http-async
-    cargo clippy --workspace --all-targets --features mmap-async-tokio
-    cargo clippy --workspace --all-targets --features tilejson
+    cargo clippy --workspace --all-targets --features __all_non_conflicting
     cargo clippy --workspace --all-targets --features s3-async-native
-    cargo clippy --workspace --all-targets --features s3-async-rustls
-    cargo clippy --workspace --all-targets --features aws-s3-async
 
 # Run all tests and checks
 test-all: check test-fmt clippy
@@ -70,15 +66,15 @@ fmt: _add_tools
 
 # Build and open code documentation
 docs:
-    cargo doc --no-deps --open
+    cargo doc --no-deps --open --features __all_non_conflicting
 
 # Quick compile without building a binary
 check:
-    RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
+    RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --features __all_non_conflicting
 
 # Generate code coverage report
 coverage *ARGS="--no-clean --open":
-    cargo llvm-cov --workspace --all-targets --include-build-script {{ARGS}}
+    cargo llvm-cov --workspace --all-targets --features __all_non_conflicting --include-build-script {{ARGS}}
 
 # Generate code coverage report to upload to codecov.io
 ci-coverage: && \
@@ -91,21 +87,18 @@ test:
     #!/usr/bin/env bash
     set -euo pipefail
     export RUSTFLAGS='-D warnings'
-    cargo test --features http-async
-    cargo test --features mmap-async-tokio
-    cargo test --features tilejson
+    cargo test --features __all_non_conflicting
     cargo test --features s3-async-native
-    cargo test --features s3-async-rustls
-    cargo test --features aws-s3-async
     cargo test
 
 # Test documentation
 test-doc:
     #!/usr/bin/env bash
     set -euo pipefail
-    RUSTDOCFLAGS="-D warnings"
-    cargo test --doc
-    cargo doc --no-deps
+    export RUSTDOCFLAGS="-D warnings"
+    cargo test --doc --features __all_non_conflicting
+    cargo test --doc --features s3-async-native
+    cargo doc --no-deps --features __all_non_conflicting
 
 # Print environment info
 env-info:

--- a/justfile
+++ b/justfile
@@ -39,9 +39,6 @@ clippy:
     cargo clippy --workspace --all-targets --features __all_non_conflicting
     cargo clippy --workspace --all-targets --features s3-async-native
 
-# Run all tests and checks
-test-all: check test-fmt clippy
-
 # Run cargo fmt and cargo clippy
 lint: fmt clippy
 

--- a/justfile
+++ b/justfile
@@ -5,9 +5,6 @@ CRATE_NAME := "pmtiles"
 @_default:
     just --list
 
-_add_tools:
-    rustup component add clippy rustfmt
-
 # Clean all build artifacts
 clean:
     cargo clean
@@ -38,7 +35,7 @@ get-crate-field field package=CRATE_NAME:
     cargo metadata --format-version 1 | jq -r '.packages | map(select(.name == "{{package}}")) | first | .{{field}}'
 
 # Run cargo clippy to lint the code
-clippy: _add_tools
+clippy:
     cargo clippy --workspace --all-targets --features __all_non_conflicting
     cargo clippy --workspace --all-targets --features s3-async-native
 
@@ -53,7 +50,7 @@ test-fmt:
     cargo fmt --all -- --check
 
 # Reformat all code `cargo fmt`. If nightly is available, use it for better results
-fmt: _add_tools
+fmt:
     #!/usr/bin/env bash
     set -euo pipefail
     if rustup component list --toolchain nightly | grep rustfmt &> /dev/null; then

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -64,7 +64,10 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
     /// Fetches tile bytes from the archive.
     pub async fn get_tile(&self, z: u8, x: u64, y: u64) -> PmtResult<Option<Bytes>> {
-        let tile_id = calc_tile_id(z, x, y);
+        self.get_tile_by_id(calc_tile_id(z, x, y)).await
+    }
+
+    pub(crate) async fn get_tile_by_id(&self, tile_id: u64) -> PmtResult<Option<Bytes>> {
         let Some(entry) = self.find_tile_entry(tile_id).await? else {
             return Ok(None);
         };

--- a/src/backend_aws_s3.rs
+++ b/src/backend_aws_s3.rs
@@ -9,9 +9,8 @@ impl AsyncPmTilesReader<AwsS3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a client, bucket and key to the
     /// archive using the `aws-sdk-s3` backend.
     ///
-    /// Fails if the [bucket] or [key] does not exist or is an invalid
-    /// archive.
-    /// (Note: S3 requests are made to validate it.)
+    /// Fails if the `bucket` or `key` does not exist or is an invalid
+    /// archive. Note that S3 requests are made to validate it.
     pub async fn new_with_client_bucket_and_path(
         client: Client,
         bucket: String,
@@ -24,9 +23,9 @@ impl AsyncPmTilesReader<AwsS3Backend, NoCache> {
 impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<AwsS3Backend, C> {
     /// Creates a new `PMTiles` reader from a client, bucket and key to the
     /// archive using the `aws-sdk-s3` backend. Caches using the designated
-    /// [cache].
+    /// `cache`.
     ///
-    /// Fails if the [bucket] or [key] does not exist or is an invalid
+    /// Fails if the `bucket` or `key` does not exist or is an invalid
     /// archive.
     /// (Note: S3 requests are made to validate it.)
     pub async fn new_with_cached_client_bucket_and_path(

--- a/src/backend_http.rs
+++ b/src/backend_http.rs
@@ -10,7 +10,7 @@ use crate::PmtError;
 impl AsyncPmTilesReader<HttpBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a URL using the Reqwest backend.
     ///
-    /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
+    /// Fails if `url` does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
     pub async fn new_with_url<U: IntoUrl>(client: Client, url: U) -> PmtResult<Self> {
         Self::new_with_cached_url(NoCache, client, url).await
     }
@@ -19,7 +19,7 @@ impl AsyncPmTilesReader<HttpBackend, NoCache> {
 impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<HttpBackend, C> {
     /// Creates a new `PMTiles` reader with cache from a URL using the Reqwest backend.
     ///
-    /// Fails if [url] does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
+    /// Fails if `url` does not exist or is an invalid archive. (Note: HTTP requests are made to validate it.)
     pub async fn new_with_cached_url<U: IntoUrl>(
         cache: C,
         client: Client,

--- a/src/backend_mmap.rs
+++ b/src/backend_mmap.rs
@@ -11,7 +11,7 @@ use crate::error::{PmtError, PmtResult};
 impl AsyncPmTilesReader<MmapBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a file path using the async mmap backend.
     ///
-    /// Fails if [p] does not exist or is an invalid archive.
+    /// Fails if `path` does not exist or is an invalid archive.
     pub async fn new_with_path<P: AsRef<Path>>(path: P) -> PmtResult<Self> {
         Self::new_with_cached_path(NoCache, path).await
     }
@@ -20,7 +20,7 @@ impl AsyncPmTilesReader<MmapBackend, NoCache> {
 impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<MmapBackend, C> {
     /// Creates a new cached `PMTiles` reader from a file path using the async mmap backend.
     ///
-    /// Fails if [p] does not exist or is an invalid archive.
+    /// Fails if `path` does not exist or is an invalid archive.
     pub async fn new_with_cached_path<P: AsRef<Path>>(cache: C, path: P) -> PmtResult<Self> {
         let backend = MmapBackend::try_from(path).await?;
 

--- a/src/backend_s3.rs
+++ b/src/backend_s3.rs
@@ -10,7 +10,7 @@ impl AsyncPmTilesReader<S3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a bucket and path to the
     /// archive using the `rust-s3` backend.
     ///
-    /// Fails if [bucket] or [path] does not exist or is an invalid archive. (Note: S3 requests are made to validate it.)
+    /// Fails if `bucket` or `path` does not exist or is an invalid archive. (Note: S3 requests are made to validate it.)
     pub async fn new_with_bucket_path(bucket: Bucket, path: String) -> PmtResult<Self> {
         Self::new_with_cached_bucket_path(NoCache, bucket, path).await
     }
@@ -18,10 +18,10 @@ impl AsyncPmTilesReader<S3Backend, NoCache> {
 
 impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<S3Backend, C> {
     /// Creates a new `PMTiles` reader from a bucket and path to the
-    /// archive using the `rust-s3` backend with a given [cache] backend.
+    /// archive using the `rust-s3` backend with a given `cache` backend.
     ///
-    /// Fails if [bucket] or [path] does not exist or is an invalid archive. (Note: S3 requests are made to validate it.)
-    /// Creates a new `PMTiles` reader with cache from a URL using the Reqwest backend.
+    /// Fails if `bucket` or `path` does not exist or is an invalid archive.
+    /// Note that S3 requests are made to validate it.
     pub async fn new_with_cached_bucket_path(
         cache: C,
         bucket: Bucket,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,15 +29,12 @@ pub trait DirectoryCache {
     ) -> impl Future<Output = DirCacheResult> + Send;
 
     /// Insert a directory into the cache, using the offset as a key.
-    /// Note that cache must be internally mutable.
+    /// Note that the cache must be internally mutable.
     fn insert_dir(&self, offset: usize, directory: Directory) -> impl Future<Output = ()> + Send;
 }
 
 pub struct NoCache;
 
-// TODO: Remove #[allow] after switching to Rust/Clippy v1.78+ in CI
-//       See https://github.com/rust-lang/rust-clippy/pull/12323
-#[allow(clippy::no_effect_underscore_binding)]
 impl DirectoryCache for NoCache {
     #[inline]
     async fn get_dir_entry(&self, _offset: usize, _tile_id: u64) -> DirCacheResult {

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -113,9 +113,8 @@ mod tests {
     use crate::tests::RASTER_FILE;
     use crate::Header;
 
-    #[test]
-    fn read_root_directory() {
-        let test_file = std::fs::File::open(RASTER_FILE).unwrap();
+    fn read_root_directory(file: &str) -> Directory {
+        let test_file = std::fs::File::open(file).unwrap();
         let mut reader = BufReader::new(test_file);
 
         let mut header_bytes = BytesMut::zeroed(HEADER_SIZE);
@@ -131,8 +130,12 @@ mod tests {
             gunzip.write_all(&directory_bytes).unwrap();
         }
 
-        let directory = Directory::try_from(decompressed.freeze()).unwrap();
+        Directory::try_from(decompressed.freeze()).unwrap()
+    }
 
+    #[test]
+    fn root_directory() {
+        let directory = read_root_directory(RASTER_FILE);
         assert_eq!(directory.entries.len(), 84);
         // Note: this is not true for all tiles, just the first few...
         for nth in 0..10 {

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Formatter};
 
 use bytes::{Buf, Bytes};
-use varint_rs::VarintReader;
+use varint_rs::VarintReader as _;
 
 use crate::error::PmtError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_markdown)]
+#![cfg_attr(all(feature = "default"), doc = include_str!("../README.md"))]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "__async")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-#![allow(clippy::doc_markdown)]
-#![cfg_attr(all(feature = "default"), doc = include_str!("../README.md"))]
-#![forbid(unsafe_code)]
+#![cfg_attr(all(feature = "__all_non_conflicting"), doc = include_str!("../README.md"))]
 
 #[cfg(feature = "__async")]
 pub mod async_reader;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -24,7 +24,9 @@ const PYRAMID_SIZE_BY_ZOOM: [u64; 21] = [
     /* 20 */ 366503875925,
 ];
 
-pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
+/// Compute the tile id for a given zoom level and tile coordinates.
+#[must_use]
+pub fn calc_tile_id(z: u8, x: u64, y: u64) -> u64 {
     // The 0/0/0 case is not needed for the base id computation, but it will fail hilbert_2d::u64::xy2h_discrete
     if z == 0 {
         return 0;
@@ -45,23 +47,23 @@ pub(crate) fn tile_id(z: u8, x: u64, y: u64) -> u64 {
 
 #[cfg(test)]
 mod test {
-    use super::tile_id;
+    use super::calc_tile_id;
 
     #[test]
     fn test_tile_id() {
-        assert_eq!(tile_id(0, 0, 0), 0);
-        assert_eq!(tile_id(1, 1, 0), 4);
-        assert_eq!(tile_id(2, 1, 3), 11);
-        assert_eq!(tile_id(3, 3, 0), 26);
-        assert_eq!(tile_id(20, 0, 0), 366503875925);
-        assert_eq!(tile_id(21, 0, 0), 1466015503701);
-        assert_eq!(tile_id(22, 0, 0), 5864062014805);
-        assert_eq!(tile_id(22, 0, 0), 5864062014805);
-        assert_eq!(tile_id(23, 0, 0), 23456248059221);
-        assert_eq!(tile_id(24, 0, 0), 93824992236885);
-        assert_eq!(tile_id(25, 0, 0), 375299968947541);
-        assert_eq!(tile_id(26, 0, 0), 1501199875790165);
-        assert_eq!(tile_id(27, 0, 0), 6004799503160661);
-        assert_eq!(tile_id(28, 0, 0), 24019198012642645);
+        assert_eq!(calc_tile_id(0, 0, 0), 0);
+        assert_eq!(calc_tile_id(1, 1, 0), 4);
+        assert_eq!(calc_tile_id(2, 1, 3), 11);
+        assert_eq!(calc_tile_id(3, 3, 0), 26);
+        assert_eq!(calc_tile_id(20, 0, 0), 366503875925);
+        assert_eq!(calc_tile_id(21, 0, 0), 1466015503701);
+        assert_eq!(calc_tile_id(22, 0, 0), 5864062014805);
+        assert_eq!(calc_tile_id(22, 0, 0), 5864062014805);
+        assert_eq!(calc_tile_id(23, 0, 0), 23456248059221);
+        assert_eq!(calc_tile_id(24, 0, 0), 93824992236885);
+        assert_eq!(calc_tile_id(25, 0, 0), 375299968947541);
+        assert_eq!(calc_tile_id(26, 0, 0), 1501199875790165);
+        assert_eq!(calc_tile_id(27, 0, 0), 6004799503160661);
+        assert_eq!(calc_tile_id(28, 0, 0), 24019198012642645);
     }
 }


### PR DESCRIPTION
* add README examples for common usecases
* rename `tile_id` to `calc_tile_id` to avoid confusion with the var
* in CI, ensure checkout happens before caching; otherwise it won't work
* use json-based retrieval of metadata
* fix `just test-all` to use the right fmt
* fix `fmt` to properly test if fmt nightly is there
* use a new meta-feature to combine all features that can work together. This fixes docs.rs as well.
* fix a few broken docs - our CI was not error-ing on them before