### PR TITLE
feat: rework tile coordinates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ reqwest-rustls-tls-native-roots = ["reqwest?/rustls-tls-native-roots"]
 reqwest-rustls-tls-webpki-roots = ["reqwest?/rustls-tls-webpki-roots"]
 
 #### These features are for the internal usage only
-# This is a list of features we use in docs.rs and other places where we want everything
+# This is a list of features we use in docs.rs and other places where we want everything.
+# This list excludes these conflicting features: s3-async-native
 __all_non_conflicting = [
     "aws-s3-async",
     "http-async",

--- a/justfile
+++ b/justfile
@@ -21,6 +21,14 @@ build:
 # Quick compile without building a binary
 check:
     cargo check --workspace --all-targets {{features_flag}}
+    @echo "--------------  Checking individual crate features"
+    cargo check --workspace --all-targets --features aws-s3-async
+    cargo check --workspace --all-targets --features http-async
+    cargo check --workspace --all-targets --features mmap-async-tokio
+    cargo check --workspace --all-targets --features s3-async-native
+    cargo check --workspace --all-targets --features s3-async-rustls
+    cargo check --workspace --all-targets --features tilejson
+    cargo check --workspace --all-targets --features write
 
 # Verify that the current version of the crate is not the same as the one published on crates.io
 check-if-published package=main_crate:
@@ -104,12 +112,18 @@ msrv:  (cargo-install 'cargo-msrv')
 semver *args:  (cargo-install 'cargo-semver-checks')
     cargo semver-checks {{features_flag}} {{args}}
 
-# Run all tests
+# Run all unit and integration tests
 test:
     cargo test --workspace --all-targets {{features_flag}}
-    cargo test --workspace --all-targets --features s3-async-native
     cargo test --workspace --doc {{features_flag}}
-    cargo test --workspace --doc --features s3-async-native
+    @echo "--------------  Testing individual crate features"
+    cargo test --workspace --all-targets --features aws-s3-async
+    cargo test --workspace --all-targets --features http-async
+    cargo test --workspace --all-targets --features mmap-async-tokio
+    cargo test --workspace --all-targets --features s3-async-native
+    cargo test --workspace --all-targets --features s3-async-rustls
+    cargo test --workspace --all-targets --features tilejson
+    cargo test --workspace --all-targets --features write
 
 # Test documentation generation
 test-doc:  (docs '')

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -1,6 +1,6 @@
 // FIXME: This seems like a bug - there are lots of u64 to usize conversions in this file,
 //        so any file larger than 4GB, or an untrusted file with bad data may crash.
-#![allow(clippy::cast_possible_truncation)]
+#![expect(clippy::cast_possible_truncation)]
 
 use std::future::Future;
 
@@ -9,14 +9,12 @@ use bytes::Bytes;
 use tokio::io::AsyncReadExt;
 
 use crate::PmtError::UnsupportedCompression;
-use crate::cache::DirCacheResult;
-#[cfg(feature = "__async")]
-use crate::cache::{DirectoryCache, NoCache};
-use crate::directory::{DirEntry, Directory};
-use crate::error::{PmtError, PmtResult};
 use crate::header::{HEADER_SIZE, MAX_INITIAL_BYTES};
-use crate::tile::calc_tile_id;
-use crate::{Compression, Header};
+use crate::{
+    Compression, DirCacheResult, DirEntry, Directory, Header, PmtError, PmtResult, TileId,
+};
+#[cfg(feature = "__async")]
+use crate::{DirectoryCache, NoCache};
 
 pub struct AsyncPmTilesReader<B, C = NoCache> {
     backend: B,
@@ -62,13 +60,22 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         })
     }
 
-    /// Fetches tile bytes from the archive.
-    pub async fn get_tile(&self, z: u8, x: u64, y: u64) -> PmtResult<Option<Bytes>> {
-        self.get_tile_by_id(calc_tile_id(z, x, y)).await
-    }
-
-    pub(crate) async fn get_tile_by_id(&self, tile_id: u64) -> PmtResult<Option<Bytes>> {
-        let Some(entry) = self.find_tile_entry(tile_id).await? else {
+    /// Fetches tile data using either [`TileCoord`](crate::TileCoord) or [`TileId`] to locate the tile.
+    ///
+    /// ```no_run
+    /// # async fn test() {
+    /// #     let backend = pmtiles::MmapBackend::try_from("").await.unwrap();
+    /// #     let reader = pmtiles::AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+    /// // Using a tile (z, x, y) coordinate to fetch a tile
+    /// let coord = pmtiles::TileCoord::new(0, 0, 0).unwrap();
+    /// let tile = reader.get_tile(coord).await.unwrap();
+    /// // Using a tile ID to fetch a tile
+    /// let tile_id = pmtiles::TileId::from(coord);
+    /// let tile = reader.get_tile(tile_id).await.unwrap();
+    /// # }
+    /// ```
+    pub async fn get_tile<ID: Into<TileId>>(&self, tile_id: ID) -> PmtResult<Option<Bytes>> {
+        let Some(entry) = self.find_tile_entry(tile_id.into()).await? else {
             return Ok(None);
         };
 
@@ -141,7 +148,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
     }
 
     /// Recursively locates a tile in the archive.
-    async fn find_tile_entry(&self, tile_id: u64) -> PmtResult<Option<DirEntry>> {
+    async fn find_tile_entry(&self, tile_id: TileId) -> PmtResult<Option<DirEntry>> {
         let entry = self.root_directory.find_tile_id(tile_id);
         if let Some(entry) = entry {
             if entry.is_leaf() {
@@ -154,7 +161,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
     async fn find_entry_rec(
         &self,
-        tile_id: u64,
+        tile_id: TileId,
         entry: &DirEntry,
         depth: u8,
     ) -> PmtResult<Option<DirEntry>> {
@@ -250,9 +257,12 @@ pub trait AsyncBackend {
 #[cfg(test)]
 #[cfg(feature = "mmap-async-tokio")]
 mod tests {
-    use super::AsyncPmTilesReader;
-    use crate::MmapBackend;
     use crate::tests::{RASTER_FILE, VECTOR_FILE};
+    use crate::{AsyncPmTilesReader, MmapBackend, TileCoord};
+
+    fn id(z: u8, x: u64, y: u64) -> TileCoord {
+        TileCoord::new(z, x, y).unwrap()
+    }
 
     #[tokio::test]
     async fn open_sanity_check() {
@@ -263,7 +273,7 @@ mod tests {
     async fn compare_tiles(z: u8, x: u64, y: u64, fixture_bytes: &[u8]) {
         let backend = MmapBackend::try_from(RASTER_FILE).await.unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
-        let tile = tiles.get_tile(z, x, y).await.unwrap().unwrap();
+        let tile = tiles.get_tile(id(z, x, y)).await.unwrap().unwrap();
 
         assert_eq!(
             tile.len(),
@@ -296,7 +306,7 @@ mod tests {
         let backend = MmapBackend::try_from(VECTOR_FILE).await.unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
 
-        let tile = tiles.get_tile(6, 31, 23).await;
+        let tile = tiles.get_tile(id(6, 31, 23)).await;
         assert!(tile.is_ok());
         assert!(tile.unwrap().is_none());
     }
@@ -306,7 +316,7 @@ mod tests {
         let backend = MmapBackend::try_from(VECTOR_FILE).await.unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
 
-        let tile = tiles.get_tile(12, 2174, 1492).await;
+        let tile = tiles.get_tile(id(12, 2174, 1492)).await;
         assert!(tile.is_ok_and(|t| t.is_some()));
     }
 
@@ -354,7 +364,7 @@ mod tests {
             (b"3", 1, 1, 1),
             (b"4", 1, 1, 0),
         ] {
-            let tile = tiles.get_tile(z, x, y).await.unwrap().unwrap();
+            let tile = tiles.get_tile(id(z, x, y)).await.unwrap().unwrap();
             assert_eq!(tile, &contents[..]);
         }
     }

--- a/src/backend_aws_s3.rs
+++ b/src/backend_aws_s3.rs
@@ -1,9 +1,7 @@
 use aws_sdk_s3::Client;
 use bytes::Bytes;
 
-use crate::async_reader::{AsyncBackend, AsyncPmTilesReader};
-use crate::cache::{DirectoryCache, NoCache};
-use crate::{PmtError, PmtResult};
+use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtError, PmtResult};
 
 impl AsyncPmTilesReader<AwsS3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a client, bucket and key to the

--- a/src/backend_http.rs
+++ b/src/backend_http.rs
@@ -2,10 +2,7 @@ use bytes::Bytes;
 use reqwest::header::{HeaderValue, RANGE};
 use reqwest::{Client, IntoUrl, Method, Request, StatusCode, Url};
 
-use crate::PmtError;
-use crate::async_reader::{AsyncBackend, AsyncPmTilesReader};
-use crate::cache::{DirectoryCache, NoCache};
-use crate::error::PmtResult;
+use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtError, PmtResult};
 
 impl AsyncPmTilesReader<HttpBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a URL using the Reqwest backend.

--- a/src/backend_mmap.rs
+++ b/src/backend_mmap.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 use bytes::{Buf, Bytes};
 use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt as _, AsyncOptions};
 
-use crate::async_reader::{AsyncBackend, AsyncPmTilesReader};
-use crate::cache::{DirectoryCache, NoCache};
-use crate::error::{PmtError, PmtResult};
+use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtError, PmtResult};
 
 impl AsyncPmTilesReader<MmapBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a file path using the async mmap backend.

--- a/src/backend_s3.rs
+++ b/src/backend_s3.rs
@@ -1,10 +1,8 @@
 use bytes::Bytes;
 use s3::Bucket;
 
-use crate::PmtResult;
-use crate::async_reader::{AsyncBackend, AsyncPmTilesReader};
-use crate::cache::{DirectoryCache, NoCache};
-use crate::error::PmtError::ResponseBodyTooLong;
+use crate::PmtError::ResponseBodyTooLong;
+use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtResult};
 
 impl AsyncPmTilesReader<S3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a bucket and path to the

--- a/src/header.rs
+++ b/src/header.rs
@@ -3,15 +3,15 @@ use std::panic::catch_unwind;
 
 use bytes::{Buf, Bytes};
 
-use crate::error::{PmtError, PmtResult};
+use crate::{PmtError, PmtResult};
 
 #[cfg(any(feature = "__async", feature = "write"))]
 pub(crate) const MAX_INITIAL_BYTES: usize = 16_384;
 #[cfg(any(test, feature = "__async", feature = "write"))]
 pub(crate) const HEADER_SIZE: usize = 127;
 
-#[allow(dead_code)]
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Header {
     pub(crate) version: u8,
     pub(crate) root_offset: u64,
@@ -183,7 +183,7 @@ static V3_MAGIC: &str = "PMTiles";
 static V2_MAGIC: &str = "PM";
 
 impl Header {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn read_coordinate_part<B: Buf>(mut buf: B) -> f32 {
         // TODO: would it be more precise to do `((value as f64) / 10_000_000.) as f32` ?
         buf.get_i32_le() as f32 / 10_000_000.
@@ -276,7 +276,7 @@ impl crate::writer::WriteTo for Header {
 
 impl Header {
     #[cfg(feature = "write")]
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn write_coordinate_part<W: std::io::Write>(writer: &mut W, value: f32) -> std::io::Result<()> {
         writer.write_all(&((value * 10_000_000.0) as i32).to_le_bytes())
     }
@@ -284,14 +284,15 @@ impl Header {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unreadable_literal, clippy::float_cmp)]
+    #![expect(clippy::unreadable_literal, clippy::float_cmp)]
     use std::fs::File;
     use std::io::Read;
     use std::num::NonZeroU64;
 
     use bytes::{Bytes, BytesMut};
 
-    use crate::header::{HEADER_SIZE, Header, TileType};
+    use crate::TileType;
+    use crate::header::{HEADER_SIZE, Header};
     use crate::tests::{RASTER_FILE, VECTOR_FILE};
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(all(feature = "__all_non_conflicting"), doc = include_str!("../README.md"))]
 
 #[cfg(feature = "__async")]
-pub mod async_reader;
+mod async_reader;
+#[cfg(feature = "__async")]
+pub use async_reader::{AsyncBackend, AsyncPmTilesReader};
+
 #[cfg(feature = "__async-aws-s3")]
 mod backend_aws_s3;
 #[cfg(feature = "http-async")]
@@ -10,12 +13,15 @@ mod backend_http;
 mod backend_mmap;
 #[cfg(feature = "__async-s3")]
 mod backend_s3;
+
 #[cfg(feature = "__async")]
-pub mod cache;
+mod cache;
+#[cfg(feature = "__async")]
+pub use cache::{DirCacheResult, DirectoryCache, HashMapCache, NoCache};
+
 mod directory;
 mod error;
 mod header;
-#[cfg(any(feature = "__async", feature = "write"))]
 mod tile;
 #[cfg(feature = "write")]
 mod writer;
@@ -40,6 +46,7 @@ pub use reqwest;
 /// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "__async-s3")]
 pub use s3;
+pub use tile::{MAX_TILE_ID, MAX_ZOOM, PYRAMID_SIZE_BY_ZOOM, TileCoord, TileId};
 /// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "tilejson")]
 pub use tilejson;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -46,9 +46,7 @@ pub const PYRAMID_SIZE_BY_ZOOM: [u64; 32] = [
     /* 28 */ 24019198012642645,
     /* 29 */ 96076792050570581,
     /* 30 */ 384307168202282325,
-    /* 31 */
-    1537228672809129301,
-    // The next value would be 6148914691236517205, but combined with 4^32 tiles it would overflow u64.
+    /* 31 */ 1537228672809129301,
 ];
 
 /// Maximum valid Tile Zoom level in the `PMTiles` format.

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -77,6 +77,17 @@ pub struct TileCoord {
 
 impl TileCoord {
     /// Create a new coordinate with the given zoom level and tile coordinates, or return `None` if the values are invalid.
+    ///
+    /// ```
+    /// # use pmtiles::TileCoord;
+    /// let coord = TileCoord::new(18, 235085, 122323).unwrap();
+    /// assert_eq!(coord.z(), 18);
+    /// assert_eq!(coord.x(), 235085);
+    /// assert_eq!(coord.y(), 122323);
+    /// assert!(TileCoord::new(32, 1, 3).is_none()); // Invalid zoom level
+    /// assert!(TileCoord::new(2, 4, 0).is_none()); // Invalid x coordinate
+    /// assert!(TileCoord::new(2, 0, 4).is_none()); // Invalid y coordinate
+    /// ```
     #[must_use]
     #[expect(clippy::cast_sign_loss)]
     pub fn new(z: u8, x: u64, y: u64) -> Option<Self> {
@@ -110,7 +121,14 @@ impl TileCoord {
 pub struct TileId(u64);
 
 impl TileId {
-    /// Create a new `TileId` from a u64 value, or return `None` if the value is invalid.
+    /// Create a new `TileId` from the u64 value, or return `None` if the value is invalid.
+    ///
+    /// ```
+    /// # use pmtiles::TileId;
+    /// assert_eq!(TileId::new(0).unwrap().value(), 0);
+    /// assert!(TileId::new(6148914691236517204).is_some());
+    /// assert!(TileId::new(6148914691236517205).is_none());
+    /// ```
     #[must_use]
     pub fn new(id: u64) -> Option<Self> {
         if id <= MAX_TILE_ID {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,7 +1,20 @@
-#![allow(clippy::unreadable_literal)]
+use hilbert_2d::Variant::Hilbert;
+use hilbert_2d::u64::{h2xy_discrete, xy2h_discrete};
 
-const PYRAMID_SIZE_BY_ZOOM: [u64; 21] = [
-    /*  0 */ 0,
+/// The pre-computed sizes of the tile pyramid for each zoom level.
+/// The size at zoom level `z` (array index) is equal to the number of tiles before that zoom level.
+///
+/// ```
+/// # use pmtiles::PYRAMID_SIZE_BY_ZOOM;
+/// let mut size_at_level = 0_u64;
+/// for z in 0..PYRAMID_SIZE_BY_ZOOM.len() {
+///     // add number of tiles at this zoom level
+///     size_at_level += 4_u64.pow(z as u32);
+///     assert_eq!(PYRAMID_SIZE_BY_ZOOM[z], size_at_level, "Invalid value at zoom {z}");
+/// }
+/// ```
+#[expect(clippy::unreadable_literal)]
+pub const PYRAMID_SIZE_BY_ZOOM: [u64; 31] = [
     /*  1 */ 1,
     /*  2 */ 5,
     /*  3 */ 21,
@@ -22,47 +35,248 @@ const PYRAMID_SIZE_BY_ZOOM: [u64; 21] = [
     /* 18 */ 22906492245,
     /* 19 */ 91625968981,
     /* 20 */ 366503875925,
+    /* 21 */ 1466015503701,
+    /* 22 */ 5864062014805,
+    /* 23 */ 23456248059221,
+    /* 24 */ 93824992236885,
+    /* 25 */ 375299968947541,
+    /* 26 */ 1501199875790165,
+    /* 27 */ 6004799503160661,
+    /* 28 */ 24019198012642645,
+    /* 29 */ 96076792050570581,
+    /* 30 */ 384307168202282325,
+    /* 31 */ 1537228672809129301,
+    // /* 32 */ 6148914691236517205,
 ];
 
-/// Compute the tile id for a given zoom level and tile coordinates.
-#[must_use]
-pub fn calc_tile_id(z: u8, x: u64, y: u64) -> u64 {
-    // The 0/0/0 case is not needed for the base id computation, but it will fail hilbert_2d::u64::xy2h_discrete
-    if z == 0 {
-        return 0;
+/// Maximum valid Tile ID in the `PMTiles` format.
+///
+/// ```
+/// # use pmtiles::MAX_TILE_ID;
+/// assert_eq!(MAX_TILE_ID, 6148914691236517204);
+/// ```
+#[expect(clippy::cast_possible_truncation)]
+pub const MAX_TILE_ID: u64 = PYRAMID_SIZE_BY_ZOOM[PYRAMID_SIZE_BY_ZOOM.len() - 1]
+    + 4_u64.pow(PYRAMID_SIZE_BY_ZOOM.len() as u32)
+    - 1;
+
+/// Maximum valid Tile Zoom level in the `PMTiles` format.
+///
+/// ```
+/// # use pmtiles::MAX_ZOOM;
+/// assert_eq!(MAX_ZOOM, 31);
+/// ```
+#[expect(clippy::cast_possible_truncation)]
+pub const MAX_ZOOM: u8 = PYRAMID_SIZE_BY_ZOOM.len() as u8;
+
+/// Represents a tile coordinate in the `PMTiles` format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TileCoord {
+    z: u8,
+    x: u64,
+    y: u64,
+}
+
+impl TileCoord {
+    /// Create a new coordinate with the given zoom level and tile coordinates, or return `None` if the values are invalid.
+    #[must_use]
+    #[expect(clippy::cast_sign_loss)]
+    pub fn new(z: u8, x: u64, y: u64) -> Option<Self> {
+        if z > MAX_ZOOM || x >= ((1 << z) as u64) || y >= ((1 << z) as u64) {
+            return None;
+        }
+        Some(Self { z, x, y })
     }
 
-    let z_ind = usize::from(z);
-    let base_id = if z_ind < PYRAMID_SIZE_BY_ZOOM.len() {
-        PYRAMID_SIZE_BY_ZOOM[z_ind]
-    } else {
-        let last_ind = PYRAMID_SIZE_BY_ZOOM.len() - 1;
-        PYRAMID_SIZE_BY_ZOOM[last_ind] + (last_ind..z_ind).map(|i| 1_u64 << (i << 1)).sum::<u64>()
-    };
+    /// Get the zoom level of this coordinate.
+    #[must_use]
+    pub fn z(&self) -> u8 {
+        self.z
+    }
 
-    let tile_id = hilbert_2d::u64::xy2h_discrete(x, y, z.into(), hilbert_2d::Variant::Hilbert);
+    /// Get the x coordinate of this tile.
+    #[must_use]
+    pub fn x(&self) -> u64 {
+        self.x
+    }
 
-    base_id + tile_id
+    /// Get the y coordinate of this tile.
+    #[must_use]
+    pub fn y(&self) -> u64 {
+        self.y
+    }
+}
+
+/// Represents a unique identifier for a tile in the `PMTiles` format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct TileId(u64);
+
+impl TileId {
+    /// Create a new `TileId` from a u64 value, or return `None` if the value is invalid.
+    #[must_use]
+    pub fn new(id: u64) -> Option<Self> {
+        if id <= MAX_TILE_ID {
+            Some(Self(id))
+        } else {
+            None
+        }
+    }
+
+    /// Get the underlying u64 value of this `TileId`.
+    #[must_use]
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<TileId> for u64 {
+    fn from(tile_id: TileId) -> Self {
+        tile_id.0
+    }
+}
+
+impl From<TileId> for TileCoord {
+    #[expect(clippy::cast_possible_truncation)]
+    fn from(id: TileId) -> Self {
+        let id = id.0;
+
+        let mut z = 0;
+        let mut size = 0;
+        for (idx, &val) in PYRAMID_SIZE_BY_ZOOM.iter().enumerate() {
+            if id < val {
+                // If we never break, it means the id is for the last zoom level.
+                // The ID has been verified to be <= MAX_TILE_ID, so this is safe.
+                break;
+            }
+            z = (idx as u8) + 1;
+            size = val;
+        }
+
+        if z > 0 {
+            // Extract the Hilbert curve index and convert it to tile coordinates
+            let (x, y) = h2xy_discrete(id - size, z.into(), Hilbert);
+            TileCoord { z, x, y }
+        } else {
+            TileCoord { z: 0, x: 0, y: 0 }
+        }
+    }
+}
+
+impl From<TileCoord> for TileId {
+    fn from(coord: TileCoord) -> Self {
+        let TileCoord { z, x, y } = coord;
+
+        // The 0/0/0 case will fail xy2h_discrete()
+        if z == 0 {
+            return TileId(0);
+        }
+        let base = PYRAMID_SIZE_BY_ZOOM
+            .get(usize::from(z - 1))
+            .expect("Invalid zoom level");
+        let tile_id = xy2h_discrete(x, y, z.into(), Hilbert);
+
+        TileId(base + tile_id)
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use super::calc_tile_id;
+    use crate::{MAX_TILE_ID, PYRAMID_SIZE_BY_ZOOM, TileCoord, TileId};
+
+    fn coord_to_id(z: u8, x: u64, y: u64) -> u64 {
+        TileId::from(TileCoord::new(z, x, y).unwrap()).value()
+    }
+
+    fn id_to_coord(id: u64) -> (u8, u64, u64) {
+        let coord = TileCoord::from(TileId::new(id).unwrap());
+        (coord.z(), coord.x(), coord.y())
+    }
 
     #[test]
+    #[expect(clippy::unreadable_literal)]
     fn test_tile_id() {
-        assert_eq!(calc_tile_id(0, 0, 0), 0);
-        assert_eq!(calc_tile_id(1, 1, 0), 4);
-        assert_eq!(calc_tile_id(2, 1, 3), 11);
-        assert_eq!(calc_tile_id(3, 3, 0), 26);
-        assert_eq!(calc_tile_id(20, 0, 0), 366503875925);
-        assert_eq!(calc_tile_id(21, 0, 0), 1466015503701);
-        assert_eq!(calc_tile_id(22, 0, 0), 5864062014805);
-        assert_eq!(calc_tile_id(23, 0, 0), 23456248059221);
-        assert_eq!(calc_tile_id(24, 0, 0), 93824992236885);
-        assert_eq!(calc_tile_id(25, 0, 0), 375299968947541);
-        assert_eq!(calc_tile_id(26, 0, 0), 1501199875790165);
-        assert_eq!(calc_tile_id(27, 0, 0), 6004799503160661);
-        assert_eq!(calc_tile_id(28, 0, 0), 24019198012642645);
+        assert_eq!(TileId::new(0).unwrap().value(), 0);
+        assert_eq!(TileId::new(MAX_TILE_ID + 1), None);
+        assert_eq!(TileId::new(MAX_TILE_ID).unwrap().value(), MAX_TILE_ID);
+
+        assert_eq!(coord_to_id(0, 0, 0), 0);
+        assert_eq!(coord_to_id(1, 1, 0), 4);
+        assert_eq!(coord_to_id(2, 1, 3), 11);
+        assert_eq!(coord_to_id(3, 3, 0), 26);
+        assert_eq!(coord_to_id(20, 0, 0), 366503875925);
+        assert_eq!(coord_to_id(21, 0, 0), 1466015503701);
+        assert_eq!(coord_to_id(22, 0, 0), 5864062014805);
+        assert_eq!(coord_to_id(23, 0, 0), 23456248059221);
+        assert_eq!(coord_to_id(24, 0, 0), 93824992236885);
+        assert_eq!(coord_to_id(25, 0, 0), 375299968947541);
+        assert_eq!(coord_to_id(26, 0, 0), 1501199875790165);
+        assert_eq!(coord_to_id(27, 0, 0), 6004799503160661);
+        assert_eq!(coord_to_id(28, 0, 0), 24019198012642645);
+        assert_eq!(coord_to_id(31, 0, 0), 1537228672809129301);
+        let max_v = (1 << 31) - 1;
+        assert_eq!(coord_to_id(31, max_v, max_v), 4611686018427387903);
+        assert_eq!(coord_to_id(31, 0, max_v), 3074457345618258602);
+        assert_eq!(coord_to_id(31, max_v, 0), 6148914691236517204);
+    }
+
+    #[test]
+    fn round_trip_ids() {
+        const LAST_PYRAMID_IDX: usize = PYRAMID_SIZE_BY_ZOOM.len() - 1;
+        for id in [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            PYRAMID_SIZE_BY_ZOOM[LAST_PYRAMID_IDX],
+            PYRAMID_SIZE_BY_ZOOM[LAST_PYRAMID_IDX] - 1,
+            PYRAMID_SIZE_BY_ZOOM[LAST_PYRAMID_IDX] + 1,
+            MAX_TILE_ID - 1,
+            MAX_TILE_ID,
+        ] {
+            test_id(id);
+        }
+        for id in 0..1000 {
+            test_id(id);
+        }
+    }
+
+    fn test_id(id: u64) {
+        let id1 = TileId::new(id).unwrap();
+        let coord1 = TileCoord::from(id1);
+        let coord2 = TileCoord::new(coord1.z, coord1.x, coord1.y).unwrap();
+        let id2 = TileId::from(coord2);
+        assert_eq!(id, id2.value(), "Failed round-trip for id={id}");
+    }
+
+    #[test]
+    fn test_calc_tile_coords() {
+        // Test round-trip conversion
+        let test_cases = [
+            (0, 0, 0),
+            (1, 1, 0),
+            (2, 1, 3),
+            (3, 3, 0),
+            (20, 0, 0),
+            (21, 0, 0),
+            (22, 0, 0),
+            (23, 0, 0),
+            (24, 0, 0),
+            (25, 0, 0),
+            (26, 0, 0),
+            (27, 0, 0),
+            (28, 0, 0),
+        ];
+
+        for (z, x, y) in test_cases {
+            let (z2, x2, y2) = id_to_coord(coord_to_id(z, x, y));
+            assert_eq!(
+                (z, x, y),
+                (z2, x2, y2),
+                "Failed round-trip for z={z}, x={x}, y={y}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## BREAKING
* Introduces two new wrapper types - `TileCoord` and `TileId` to ensure no invalid data is passed from the user
* All internal APIs now also use `TileId` to ensure consistency and extra validation
* Allows back and forth conversion between the two types
* Flatten exported API surface to be top level only -- this crate is too small to have complex namespaces
* `TileId` can be retrieved, but cannot be created (we may change this later)?
* Reworked conversion code a bit
* Make the conversion table cover the whole range of possible values -- `zoom <= 31`

### Example

```rust
// Using a tile (z, x, y) coordinate to fetch a tile
let coord = pmtiles::TileCoord::new(0, 0, 0).unwrap();
let tile = reader.get_tile(coord).await.unwrap();

// Using a tile ID to fetch a tile
let tile_id: TileId = coord.into();
let tile = reader.get_tile(tile_id).await.unwrap();
```


This should clear up some code for the iteration in #49 - I used some code from @keichan34's code here (please review!)