### PR TITLE
perf: use `u32` instead of `u64` for `(x,y)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ async-compression = { version = "0.4", features = ["gzip"] }
 aws-sdk-s3 = { version = "1.49.0", optional = true }
 bytes = "1"
 countio = { version = "0.2.19", optional = true }
+fast_hilbert = "2.0.1"
 flate2 = { version = "1", optional = true }
 fmmap = { version = "0.4", default-features = false, optional = true }
-hilbert_2d = "1"
 reqwest = { version = "0.12.4", default-features = false, optional = true }
 rust-s3 = { version = "0.35.1", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ PRs welcome!
 use bytes::Bytes;
 use pmtiles::{AsyncPmTilesReader, TileCoord};
 
-async fn get_tile(z: u8, x: u64, y: u64) -> Option<Bytes> {
+async fn get_tile(z: u8, x: u32, y: u32) -> Option<Bytes> {
   let file = "example.pmtiles";
   // Use `new_with_cached_path` for better performance
   let reader = AsyncPmTilesReader::new_with_path(file).await.unwrap();
@@ -55,7 +55,7 @@ use bytes::Bytes;
 use pmtiles::{AsyncPmTilesReader, HashMapCache, TileCoord};
 use pmtiles::reqwest::Client;  // Re-exported Reqwest crate
 
-async fn get_tile(z: u8, x: u64, y: u64) -> Option<Bytes> {
+async fn get_tile(z: u8, x: u32, y: u32) -> Option<Bytes> {
   let cache = HashMapCache::default();
   let client = Client::builder().use_rustls_tls().build().unwrap();
   let url = "https://protomaps.github.io/PMTiles/protomaps(vector)ODbL_firenze.pmtiles";
@@ -74,7 +74,7 @@ use bytes::Bytes;
 use pmtiles::{AsyncPmTilesReader, HashMapCache, TileCoord};
 use pmtiles::aws_sdk_s3::Client; // Re-exported AWS SDK S3 client
 
-async fn get_tile(client: Client, z: u8, x: u64, y: u64) -> Option<Bytes> {
+async fn get_tile(client: Client, z: u8, x: u32, y: u32) -> Option<Bytes> {
   let cache = HashMapCache::default();
   let bucket = "https://s3.example.com".to_string();
   let key = "example.pmtiles".to_string();

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -260,7 +260,7 @@ mod tests {
     use crate::tests::{RASTER_FILE, VECTOR_FILE};
     use crate::{AsyncPmTilesReader, MmapBackend, TileCoord};
 
-    fn id(z: u8, x: u64, y: u64) -> TileCoord {
+    fn id(z: u8, x: u32, y: u32) -> TileCoord {
         TileCoord::new(z, x, y).unwrap()
     }
 
@@ -270,7 +270,7 @@ mod tests {
         AsyncPmTilesReader::try_from_source(backend).await.unwrap();
     }
 
-    async fn compare_tiles(z: u8, x: u64, y: u64, fixture_bytes: &[u8]) {
+    async fn compare_tiles(z: u8, x: u32, y: u32, fixture_bytes: &[u8]) {
         let backend = MmapBackend::try_from(RASTER_FILE).await.unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
         let tile = tiles.get_tile(id(z, x, y)).await.unwrap().unwrap();

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,5 +1,4 @@
-use hilbert_2d::Variant::Hilbert;
-use hilbert_2d::u64::{h2xy_discrete, xy2h_discrete};
+use fast_hilbert::{h2xy, xy2h};
 
 /// The pre-computed sizes of the tile pyramid for each zoom level.
 /// The size at zoom level `z` (array index) is equal to the number of tiles before that zoom level.
@@ -168,12 +167,8 @@ impl From<TileId> for TileCoord {
 
         if z > 0 {
             // Extract the Hilbert curve index and convert it to tile coordinates
-            let (x, y) = h2xy_discrete(id - size, z.into(), Hilbert);
-            TileCoord {
-                z,
-                x: x as u32,
-                y: y as u32,
-            }
+            let (x, y) = h2xy::<u32>(id - size, z.into());
+            TileCoord { z, x, y }
         } else {
             TileCoord { z: 0, x: 0, y: 0 }
         }
@@ -190,7 +185,7 @@ impl From<TileCoord> for TileId {
             let base = PYRAMID_SIZE_BY_ZOOM
                 .get(usize::from(z))
                 .expect("TileCoord should be valid"); // see TileCoord::new
-            let tile_id = xy2h_discrete(u64::from(x), u64::from(y), z.into(), Hilbert);
+            let tile_id = xy2h(x, y, z.into());
 
             TileId(base + tile_id)
         }

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -167,7 +167,7 @@ impl From<TileId> for TileCoord {
 
         if z > 0 {
             // Extract the Hilbert curve index and convert it to tile coordinates
-            let (x, y) = h2xy::<u32>(id - size, z.into());
+            let (x, y) = h2xy::<u32>(id - size, z);
             TileCoord { z, x, y }
         } else {
             TileCoord { z: 0, x: 0, y: 0 }
@@ -185,7 +185,7 @@ impl From<TileCoord> for TileId {
             let base = PYRAMID_SIZE_BY_ZOOM
                 .get(usize::from(z))
                 .expect("TileCoord should be valid"); // see TileCoord::new
-            let tile_id = xy2h(x, y, z.into());
+            let tile_id = xy2h(x, y, z);
 
             TileId(base + tile_id)
         }


### PR DESCRIPTION
Migrate to the [fast_hilbert]( https://crates.io/crates/fast_hilbert) crate which claims significantly faster performance. Closes #63   Also, it turns out we have been using u64 values for x/y coordinates, which is pointless because hilbert only encodes a u64, which means u32 is the max allowed for individual tile coordinates. Since the new algo API is much cleaner, it also matches perfectly with the original changes of this PR.