### PR TITLE
chore: automate release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with: { tool: just }
-      - name: Ensure this crate has not yet been published
-        run: just check-if-published
       - run: just ci-test
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          feature-group: only-explicit-features
-          features: __all_non_conflicting
 
   test-msrv:
     name: Test MSRV
@@ -71,22 +64,43 @@ jobs:
   # This job checks if any of the previous jobs failed or were canceled.
   # This approach also allows some jobs to be skipped if they are not needed.
   ci-passed:
-    if: always()
     needs: [ test, test-msrv ]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
 
-  release:
-    # Some dependencies of the `ci-passed` job might be skipped, but we still want to run if the `ci-passed` job succeeded.
-    if: always() && startsWith(github.ref, 'refs/tags/') && needs.ci-passed.result == 'success'
-    name: Publish to crates.io
+  # Release unpublished packages or create a PR with changes
+  release-plz:
     needs: [ ci-passed ]
+    if: |
+      always()
+      && needs.ci-passed.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && github.repository_owner == 'stadiamaps'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
-      - name: Publish to crates.io
-        run: cargo publish
+        with: { fetch-depth: 0 }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io if crate's version is newer
+        uses: release-plz/action@v0.5
+        id: release
+        with: { command: release }
         env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: If version is the same, create a PR proposing new version and changelog for the next release
+        uses: release-plz/action@v0.5
+        if: ${{ steps.release.outputs.releases_created == 'false' }}
+        with: { command: release-pr }
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,8 +1,6 @@
 name: Dependabot auto-merge
 on: pull_request
 
-permissions: write-all
-
 jobs:
   dependabot:
     runs-on: ubuntu-latest
@@ -11,17 +9,15 @@ jobs:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
-/target
-/Cargo.lock
-/.idea
+**/*.rs.bk
+*.pdb
+.idea/
+.vscode/
+debug/
+target/
+temp/
+tmp/
+venv/
+
+# This is a library, no lock
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.15.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ writer.finalize().unwrap();
 
 Licensed under either of
 
-* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/licenses/MIT>)
   at your option.
 
 ### Test Data License

--- a/justfile
+++ b/justfile
@@ -109,6 +109,9 @@ get-msrv package=main_crate:  (get-crate-field 'rust_version' package)
 msrv:  (cargo-install 'cargo-msrv')
     cargo msrv find --write-msrv --ignore-lockfile {{features_flag}}
 
+release *args='':  (cargo-install 'release-plz')
+    release-plz {{args}}
+
 # Check semver compatibility with prior published version. Install it with `cargo install cargo-semver-checks`
 semver *args:  (cargo-install 'cargo-semver-checks')
     cargo semver-checks {{features_flag}} {{args}}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,4 @@
+[workspace]
+dependencies_update = true
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"


### PR DESCRIPTION
Copy release-plz settings I used for other projects like https://github.com/georust/tilejson and all of my personal ones

## Main idea
* on merge to `main`, if the current **version** is the same as published, automatically creates a new PR that proposes to bump the crate version to a new value. The bump is automatically computed by semver checker based on API changes. The PR also suggests changes to the changelog file based on commit history.  If other PRs are merged to main, the automatic update PR is also updated.
* Once the update PR itself is merged (i.e. the version of the crate changes), automatically publish new version to crates.io, and create a release page in github
* Note that there is no release until crate version changes in main (that's why this PR rolls back the version to be the same as published)

## TODO
Please create `RELEASE_PLZ_TOKEN` secret by following https://release-plz.dev/docs/github/token instructions