### PR TITLE
feat(object_store): add an `object_store::ObjectStore` backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ __all_non_conflicting = [
     "object-store-http",
     "object-store-aws",
     "object-store-azure",
+    "object-store-gcp",
 ]
 __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde_json = { version = "1", optional = true }
 thiserror = "2"
 tilejson = { version = "0.4", optional = true }
 tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
-url = {version = "2", optional = true }
+url = { version = "2", optional = true }
 varint-rs = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
 write = ["dep:countio", "dep:flate2"]
 
+object-store = ["dep:object_store", "dep:url"]
+object-store-fs = ["object-store", "object_store/fs"]
+object-store-http = ["object-store", "object_store/http"]
+object-store-aws = ["object-store", "object_store/aws"]
+object-store-azure = ["object-store", "object_store/azure"]
+
 # Forward some of the common features to reqwest dependency
 reqwest-default = ["reqwest?/default"]
 reqwest-native-tls = ["reqwest?/native-tls"]
@@ -42,6 +48,10 @@ __all_non_conflicting = [
     "s3-async-rustls",
     "tilejson",
     "write",
+    "object-store",
+    "object-store-http",
+    "object-store-aws",
+    "object-store-azure",
 ]
 __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]
@@ -60,6 +70,7 @@ fast_hilbert = "2.0.1"
 flate2 = { version = "1", optional = true }
 fmmap = { version = "0.4", default-features = false, optional = true }
 futures-util = { version = "0.3", optional = true }
+object_store = { version = "0.12", optional = true, default-features = false }
 reqwest = { version = "0.12.4", default-features = false, optional = true }
 rust-s3 = { version = "0.35.1", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }
@@ -67,6 +78,7 @@ serde_json = { version = "1", optional = true }
 thiserror = "2"
 tilejson = { version = "0.4", optional = true }
 tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
+url = {version = "2", optional = true }
 varint-rs = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ object-store-fs = ["object-store", "object_store/fs"]
 object-store-http = ["object-store", "object_store/http"]
 object-store-aws = ["object-store", "object_store/aws"]
 object-store-azure = ["object-store", "object_store/azure"]
+object-store-gcp = ["object-store", "object_store/gcp"]
 
 # Forward some of the common features to reqwest dependency
 reqwest-default = ["reqwest?/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ __all_non_conflicting = [
     "tilejson",
     "write",
     "object-store",
+    "object-store-fs",
     "object-store-http",
     "object-store-aws",
     "object-store-azure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,7 @@ s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
 write = ["dep:countio", "dep:flate2"]
 
-object-store = ["dep:object_store", "dep:url"]
-object-store-fs = ["object-store", "object_store/fs"]
-object-store-http = ["object-store", "object_store/http"]
-object-store-aws = ["object-store", "object_store/aws"]
-object-store-azure = ["object-store", "object_store/azure"]
-object-store-gcp = ["object-store", "object_store/gcp"]
+object-store = ["dep:object_store"]
 
 # Forward some of the common features to reqwest dependency
 reqwest-default = ["reqwest?/default"]
@@ -81,7 +76,6 @@ serde_json = { version = "1", optional = true }
 thiserror = "2"
 tilejson = { version = "0.4", optional = true }
 tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
-url = { version = "2", optional = true }
 varint-rs = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ varint-rs = "2"
 flate2 = "1"
 fmmap = { version = "0.4", features = ["tokio"] }
 reqwest = { version = "0.12.4", features = ["rustls-tls-webpki-roots"] }
+rstest = "0.26.1"
 tempfile = "3.13.0"
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ varint-rs = "2"
 [dev-dependencies]
 flate2 = "1"
 fmmap = { version = "0.4", features = ["tokio"] }
+httpmock = "0.7.0"
 reqwest = { version = "0.12.4", features = ["rustls-tls-webpki-roots"] }
 rstest = "0.26.1"
 tempfile = "3.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,6 @@ __all_non_conflicting = [
     "tilejson",
     "write",
     "object-store",
-    "object-store-fs",
-    "object-store-http",
-    "object-store-aws",
-    "object-store-azure",
-    "object-store-gcp",
 ]
 __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]
@@ -86,6 +81,7 @@ reqwest = { version = "0.12.4", features = ["rustls-tls-webpki-roots"] }
 rstest = "0.26.1"
 tempfile = "3.13.0"
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
+url = "2"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ originally created by Brandon Liu for Protomaps.
   - Async `mmap` (Tokio) for local files
   - Async `http` and `https` (Reqwest + Tokio) for URLs
   - Async `s3` (Rust-S3 + Tokio) for S3-compatible buckets
+  - Async `s3`/`azure`/`gcp`/`fs`/`http`/`mem`/custom ([`object_store`](https://docs.rs/object_store))
 - Creating `PMTile` archives
 
 ## Plans & TODOs

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -371,7 +371,7 @@ mod tests {
     #[tokio::test]
     async fn get_tiles_object_store(#[case] coord: TileCoord, #[case] fixture_bytes: &[u8]) {
         let url = url::Url::parse(RASTER_FILE).unwrap();
-        let backend = crate::ObjectStorageBackend::try_from(&url).unwrap();
+        let backend = crate::ObjectStoreBackend::try_from(&url).unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
         let tile = tiles.get_tile_decompressed(coord).await.unwrap().unwrap();
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -372,11 +372,13 @@ mod tests {
         use object_store::{ObjectStore, WriteMultipart};
 
         let store = Box::new(object_store::memory::InMemory::new());
-        
+
         let upload_path = object_store::path::Path::from("file.pmtiles");
-        let upload =  store.put_multipart(&upload_path).await.unwrap();
+        let upload = store.put_multipart(&upload_path).await.unwrap();
         let mut write = WriteMultipart::new(upload);
-        write.write(include_bytes!("../fixtures/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles"));
+        write.write(include_bytes!(
+            "../fixtures/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles"
+        ));
         write.finish().await.unwrap();
         let backend = crate::ObjectStoreBackend::new(store, upload_path);
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -446,25 +446,20 @@ mod tests {
     }
 
     #[rstest]
-    #[case(0, 0, 0, b"0")]
-    #[case(1, 0, 0, b"1")]
-    #[case(1, 0, 1, b"2")]
-    #[case(1, 1, 1, b"3")]
-    #[case(1, 1, 0, b"4")]
+    #[case(id(0, 0, 0), b"0")]
+    #[case(id(1, 0, 0), b"1")]
+    #[case(id(1, 0, 1), b"2")]
+    #[case(id(1, 1, 1), b"3")]
+    #[case(id(1, 1, 0), b"4")]
     #[tokio::test]
-    async fn test_martin_675(
-        #[case] z: u8,
-        #[case] x: u32,
-        #[case] y: u32,
-        #[case] expected_contents: &[u8],
-    ) {
+    async fn test_martin_675(#[case] coord: TileCoord, #[case] expected_contents: &[u8]) {
         let backend = MmapBackend::try_from("fixtures/leaf.pmtiles")
             .await
             .unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
         // Verify that the test case does contain a leaf directory
         assert_ne!(0, tiles.get_header().leaf_length);
-        let tile = tiles.get_tile(id(z, x, y)).await.unwrap().unwrap();
+        let tile = tiles.get_tile(coord).await.unwrap().unwrap();
         assert_eq!(tile, expected_contents);
     }
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -368,7 +368,7 @@ mod tests {
     #[case(id(2, 2, 2), include_bytes!("../fixtures/2_2_2.png"))]
     #[case(id(3, 4, 5), include_bytes!("../fixtures/3_4_5.png"))]
     #[tokio::test]
-    #[cfg(feature="object-store")]
+    #[cfg(feature = "object-store")]
     async fn get_tiles_object_store(#[case] coord: TileCoord, #[case] fixture_bytes: &[u8]) {
         use object_store::{ObjectStore, WriteMultipart};
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -368,6 +368,7 @@ mod tests {
     #[case(id(2, 2, 2), include_bytes!("../fixtures/2_2_2.png"))]
     #[case(id(3, 4, 5), include_bytes!("../fixtures/3_4_5.png"))]
     #[tokio::test]
+    #[cfg(feature="object-store")]
     async fn get_tiles_object_store(#[case] coord: TileCoord, #[case] fixture_bytes: &[u8]) {
         use object_store::{ObjectStore, WriteMultipart};
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -370,8 +370,13 @@ mod tests {
     #[case(id(3, 4, 5), include_bytes!("../fixtures/3_4_5.png"))]
     #[tokio::test]
     async fn get_tiles_object_store(#[case] coord: TileCoord, #[case] fixture_bytes: &[u8]) {
-        let url = url::Url::parse(RASTER_FILE).unwrap();
-        let backend = crate::ObjectStoreBackend::try_from(&url).unwrap();
+        use std::path::PathBuf;
+
+        // object_store expects an absolute url-path
+        let file = PathBuf::from(RASTER_FILE).canonicalize().unwrap();
+        let fileurl = format!("file://{}", file.to_string_lossy());
+
+        let backend = crate::ObjectStoreBackend::try_from(&fileurl.parse().unwrap()).unwrap();
         let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
         let tile = tiles.get_tile_decompressed(coord).await.unwrap().unwrap();
 

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -1,7 +1,7 @@
 //! Object store backend implementation using the [`object_store`] crate.
 //!
 //! This backend provides a unified interface for accessing `PMTiles` from various
-//! storage systems including Files, HTTP, S3, Azure Blob Storage, and Google Cloud Storage.
+//! storage systems including S3, Azure Blob Storage, Google Cloud Storage, local files, HTTP/WebDAV Storage, memory and custom implementations.
 
 use std::ops::Range;
 

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -14,9 +14,8 @@ use std::ops::Range;
 use bytes::Bytes;
 use object_store::ObjectStore;
 use object_store::path::Path;
-use url::Url;
 
-use crate::{AsyncBackend, PmtError, PmtResult};
+use crate::{AsyncBackend, PmtResult};
 
 /// Backend implementation using the [`object_store`] crate for unified storage access.
 ///
@@ -31,14 +30,14 @@ use crate::{AsyncBackend, PmtError, PmtResult};
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use object_store::memory::InMemory;
 /// use pmtiles::ObjectStoreBackend;
 ///
 /// let store = Box::new(InMemory::new());
-/// let backend = ObjectStoreBackend::new(&url).unwrap();
-/// # assert_eq!(backend.store().to_string(), "InMemory")
-/// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles")
+/// let backend = ObjectStoreBackend::new(store, "tiles.pmtiles");
+/// # assert_eq!(backend.store().to_string(), "InMemory");
+/// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles");
 /// ```
 #[derive(Debug)]
 pub struct ObjectStoreBackend {
@@ -55,29 +54,29 @@ impl ObjectStoreBackend {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use object_store::memory::InMemory;
     /// use pmtiles::ObjectStoreBackend;
     ///
     /// let store = Box::new(InMemory::new());
     /// let backend = ObjectStoreBackend::new(store, "tiles.pmtiles");
-    /// # assert_eq!(backend.store().to_string(), "InMemory")
-    /// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles")
+    /// #   assert_eq!(backend.store().to_string(), "InMemory");
+    /// #   assert_eq!(backend.path().as_ref(), "tiles.pmtiles");
     /// ```
     ///
     /// You can also parse urls from urls as following.
     /// The supported url schemes are dependent on the [`object_store`]-features.
     /// See [`object_store::parse_url`] for further details.
     ///
-    /// ```rust
+    /// ```
     /// use pmtiles::ObjectStoreBackend;
     /// use url::Url;
     ///
-    /// let url = Url::parse("memory://tiles.pmtiles").unwrap();
-    /// let (url, path) = object_store::parse_url(&url);
-    /// let backend = ObjectStoreBackend::new(&url).unwrap();
-    /// # assert_eq!(backend.store().to_string(), "InMemory")
-    /// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles")
+    /// let url = Url::parse("memory:///tiles.pmtiles").unwrap();
+    /// let (store, path) = object_store::parse_url(&url).unwrap();
+    /// let backend = ObjectStoreBackend::new(store, path);
+    /// # assert_eq!(backend.store().to_string(), "InMemory");
+    /// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles");
     /// ```
     pub fn new<P: Into<Path>>(store: Box<dyn ObjectStore>, path: P) -> Self {
         Self {
@@ -117,6 +116,7 @@ mod tests {
     use object_store::memory::InMemory;
 
     use super::*;
+    use crate::PmtError;
 
     #[test]
     fn test_new_backend() {

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -228,7 +228,8 @@ mod tests {
 
         let mock = MockServer::start();
         let server = mock.mock(|when, then| {
-            when.path("/foo/bar").and(|when| when.header("User-Agent", "pmties"));
+            when.path("/foo/bar")
+                .and(|when| when.header("User-Agent", "pmties"));
             then.status(200);
         });
         let url = mock.url("/foo/bar").parse().unwrap();

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -138,6 +138,13 @@ impl AsyncBackend for ObjectStoreBackend {
     }
 }
 
+#[cfg(any(
+    feature = "object-store-fs",
+    feature = "object-store-http",
+    feature = "object-store-aws",
+    feature = "object-store-azure",
+    feature = "object-store-gcp",
+))]
 impl TryFrom<&Url> for ObjectStoreBackend {
     type Error = PmtError;
 
@@ -153,6 +160,13 @@ impl TryFrom<&Url> for ObjectStoreBackend {
     }
 }
 
+#[cfg(any(
+    feature = "object-store-fs",
+    feature = "object-store-http",
+    feature = "object-store-aws",
+    feature = "object-store-azure",
+    feature = "object-store-gcp",
+))]
 impl<I, K, V> TryFrom<(&Url, I)> for ObjectStoreBackend
 where
     I: IntoIterator<Item = (K, V)>,

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -68,7 +68,7 @@ impl ObjectStoreBackend {
     /// You can also parse urls from urls as following.
     /// The supported url schemes are dependent on the [`object_store`]-features.
     /// See [`object_store::parse_url`] for further details.
-    /// 
+    ///
     /// ```rust
     /// use pmtiles::ObjectStoreBackend;
     /// use url::Url;

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -1,7 +1,13 @@
 //! Object store backend implementation using the [`object_store`] crate.
 //!
-//! This backend provides a unified interface for accessing `PMTiles` from various
-//! storage systems including S3, Azure Blob Storage, Google Cloud Storage, local files, HTTP/WebDAV Storage, memory and custom implementations.
+//! This backend provides a unified interface for accessing `PMTiles` from various storage systems including:
+//! - AWS S3,
+//! - Azure Blob Storage,
+//! - Google Cloud Storage,
+//! - local files,
+//! - HTTP/WebDAV Storage,
+//! - memory and
+//! - custom implementations
 
 use std::ops::Range;
 
@@ -15,53 +21,24 @@ use crate::{AsyncBackend, PmtError, PmtResult};
 /// Backend implementation using the [`object_store`] crate for unified storage access.
 ///
 /// This backend can work with any storage system supported by [`object_store`]:
-/// - [AWS S3](https://aws.amazon.com/s3/) via `object-store-aws` feature
-/// - [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/) via `object-store-azure` feature
-/// - [Google Cloud Storage](https://cloud.google.com/storage) via `object-store-gcp` feature
-/// - Local files via `object-store-fs` feature
-/// - [HTTP/WebDAV Storage](https://datatracker.ietf.org/doc/html/rfc2518) via `object-store-http` feature
-/// - (mostly for testing) Memory
-/// - Custom implementations
+/// - [AWS S3](https://aws.amazon.com/s3/)
+/// - [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/)
+/// - [Google Cloud Storage](https://cloud.google.com/storage)
+/// - Local files
+/// - [HTTP/WebDAV Storage](https://datatracker.ietf.org/doc/html/rfc2518)
+/// - Memory
+/// - Custom implementations in your/other crates (like [`object_store_opendal`](https://crates.io/crates/object_store_opendal), [`hdfs_native_object_store`](https://crates.io/crates/hdfs_native_object_store), ...)
 ///
-/// # Examples
+/// # Example
 ///
-/// Creating a backend from a URL using `try_from`:
 /// ```rust
-/// # use pmtiles::ObjectStoreBackend;
-/// # use url::Url;
-/// #
-/// // Create from any supported URL scheme
-/// // For example http  (under object-store-http feature)
-/// let url = Url::parse("https://example.com/tiles.pmtiles").unwrap();
-/// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-/// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles");
-/// # assert_eq!(backend.store().to_string(), "HttpStore");
+/// use object_store::memory::InMemory;
+/// use pmtiles::ObjectStoreBackend;
 ///
-/// // Works with S3 URLs too (under object-store-aws feature)
-/// let url = Url::parse("s3://bucket-name/path/tiles.pmtiles").unwrap();
-/// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-/// # assert_eq!(backend.path().as_ref(), "path/tiles.pmtiles");
-/// # assert_eq!(backend.store().to_string(), "AmazonS3(bucket-name)");
-///
-/// // Or with URLs that encode the bucket name in the URL path
-/// let url = Url::parse("https://ACCOUNT_ID.r2.cloudflarestorage.com/bucket/path").unwrap();
-/// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-/// # assert_eq!(backend.path().as_ref(), "path");
-/// # assert_eq!(backend.store().to_string(), "AmazonS3(bucket)");
-/// ```
-///
-/// Creating a backend manually:
-/// ```rust
-/// # #[cfg(feature = "object-store-http")]
-/// # {
-/// let store = Box::new(
-///     object_store::http::HttpBuilder::new()
-///         .with_url("https://example.com")
-///         .build()
-///         .unwrap()
-/// );
-/// let backend = pmtiles::ObjectStoreBackend::new(store, "tiles.pmtiles");
-/// # }
+/// let store = Box::new(InMemory::new());
+/// let backend = ObjectStoreBackend::new(&url).unwrap();
+/// # assert_eq!(backend.store().to_string(), "InMemory")
+/// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles")
 /// ```
 #[derive(Debug)]
 pub struct ObjectStoreBackend {
@@ -77,33 +54,30 @@ impl ObjectStoreBackend {
     /// * `path` - Path to the file within the store
     ///
     /// # Example
-    /// ```rust,ignore
-    /// # #[cfg(feature = "object-store-http")]
-    /// # {
-    /// use object_store::http::HttpBuilder;
-    /// use pmtiles::ObjectStoreBackend;
-    /// use std::sync::Arc;
     ///
-    /// let store = Arc::new(
-    ///     HttpBuilder::new()
-    ///         .with_url("https://example.com")
-    ///         .build()
-    ///         .unwrap()
-    /// );
+    /// ```rust
+    /// use object_store::memory::InMemory;
+    /// use pmtiles::ObjectStoreBackend;
+    ///
+    /// let store = Box::new(InMemory::new());
     /// let backend = ObjectStoreBackend::new(store, "tiles.pmtiles");
-    /// # }
+    /// # assert_eq!(backend.store().to_string(), "InMemory")
+    /// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles")
     /// ```
     ///
-    /// For convenience, you can also create backends directly from URLs:
-    /// ```rust,ignore
-    /// # #[cfg(feature = "object-store-http")]
-    /// # {
+    /// You can also parse urls from urls as following.
+    /// The supported url schemes are dependent on the [`object_store`]-features.
+    /// See [`object_store::parse_url`] for further details.
+    /// 
+    /// ```rust
     /// use pmtiles::ObjectStoreBackend;
     /// use url::Url;
     ///
-    /// let url = Url::parse("https://example.com/tiles.pmtiles").unwrap();
-    /// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-    /// # }
+    /// let url = Url::parse("memory://tiles.pmtiles").unwrap();
+    /// let (url, path) = object_store::parse_url(&url);
+    /// let backend = ObjectStoreBackend::new(&url).unwrap();
+    /// # assert_eq!(backend.store().to_string(), "InMemory")
+    /// # assert_eq!(backend.path().as_ref(), "tiles.pmtiles")
     /// ```
     pub fn new<P: Into<Path>>(store: Box<dyn ObjectStore>, path: P) -> Self {
         Self {
@@ -138,63 +112,6 @@ impl AsyncBackend for ObjectStoreBackend {
     }
 }
 
-#[cfg(any(
-    feature = "object-store-fs",
-    feature = "object-store-http",
-    feature = "object-store-aws",
-    feature = "object-store-azure",
-    feature = "object-store-gcp",
-))]
-impl TryFrom<&Url> for ObjectStoreBackend {
-    type Error = PmtError;
-
-    /// Create an [`ObjectStoreBackend`] based on the provided `url`
-    ///
-    /// The url can be for example:
-    /// * `file:///path/to/my/file`
-    /// * `s3://bucket/path`
-    /// * `https://example.com/path.pmtiles`
-    fn try_from(value: &Url) -> Result<Self, Self::Error> {
-        let (store, path) = object_store::parse_url(value)?;
-        Ok(ObjectStoreBackend { store, path })
-    }
-}
-
-#[cfg(any(
-    feature = "object-store-fs",
-    feature = "object-store-http",
-    feature = "object-store-aws",
-    feature = "object-store-azure",
-    feature = "object-store-gcp",
-))]
-impl<I, K, V> TryFrom<(&Url, I)> for ObjectStoreBackend
-where
-    I: IntoIterator<Item = (K, V)>,
-    K: AsRef<str>,
-    V: Into<String>,
-{
-    type Error = PmtError;
-
-    /// Create an [`ObjectStoreBackend`] based on the provided `url` and `options`
-    ///
-    /// The url can be for example:
-    /// * `file:///path/to/my/file`
-    /// * `s3://bucket/path`
-    /// * `https://example.com/path.pmtiles`
-    ///
-    /// Arguments:
-    /// * `url`: The URL to parse
-    /// * `options`: A list of key-value pairs to pass to the [`ObjectStore`] builder.
-    ///   Note different object stores accept different configuration options, so
-    ///   the options that are read depends on the `url` value. One common pattern
-    ///   is to pass configuration information via process variables using
-    ///   [`std::env::vars`].
-    fn try_from((url, options): (&Url, I)) -> Result<Self, Self::Error> {
-        let (store, path) = object_store::parse_url_opts(url, options)?;
-        Ok(ObjectStoreBackend { store, path })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use object_store::memory::InMemory;
@@ -211,7 +128,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_error_conversion() {
+    async fn test_error_nonexistant() {
         let store = Box::new(InMemory::new());
         let backend = ObjectStoreBackend::new(store, "nonexistent.pmtiles");
 
@@ -220,40 +137,5 @@ mod tests {
             result.unwrap_err(),
             PmtError::ObjectStore(object_store::Error::NotFound { .. })
         ));
-    }
-
-    #[tokio::test]
-    async fn basic_http_test() {
-        let url_http =
-            Url::parse("https://protomaps.github.io/PMTiles/protomaps(vector)ODbL_firenze.pmtiles")
-                .unwrap();
-        let backend = ObjectStoreBackend::try_from(&url_http).unwrap();
-        assert_eq!(
-            backend.path().as_ref(),
-            "PMTiles/protomaps(vector)ODbL_firenze.pmtiles"
-        );
-        assert_eq!(backend.store().to_string(), "HttpStore");
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "object-store-http")]
-    async fn test_try_from_with_http_options() {
-        use httpmock::MockServer;
-
-        let mock = MockServer::start();
-        let server = mock.mock(|when, then| {
-            when.path("/foo/bar")
-                .and(|when| when.header("User-Agent", "pmties"));
-            then.status(200);
-        });
-        let url = mock.url("/foo/bar").parse().unwrap();
-        dbg!(mock.url("/foo/bar"));
-
-        let opts = [("user_agent", "pmties"), ("allow_http", "true")];
-        let backend = ObjectStoreBackend::try_from((&url, opts)).unwrap();
-        assert_eq!(backend.path().as_ref(), "foo/bar");
-        backend.store().get(backend.path()).await.unwrap();
-
-        server.assert_hits(1);
     }
 }

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -168,7 +168,10 @@ mod tests {
         let backend = ObjectStoreBackend::new(store, "nonexistent.pmtiles");
 
         let result = backend.read(0, 100).await;
-        assert!(matches!(result.unwrap_err(), PmtError::ObjectStore(object_store::Error::NotFound { .. })));
+        assert!(matches!(
+            result.unwrap_err(),
+            PmtError::ObjectStore(object_store::Error::NotFound { .. })
+        ));
     }
 
     #[tokio::test]

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -34,17 +34,17 @@ use crate::{AsyncBackend, PmtError, PmtResult};
 /// // For example http  (under object-store-http feature)
 /// let url = Url::parse("https://example.com/tiles.pmtiles").unwrap();
 /// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-/// # assert_eq!(&backend.path(), "tiles.pmtiles");
+/// # assert_eq!(&backend.path().to_string(), "tiles.pmtiles");
 ///
 /// // Works with S3 URLs too (under object-store-aws feature)
 /// let url = Url::parse("s3://bucket-name/path/tiles.pmtiles").unwrap();
 /// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-/// # assert_eq!(&backend.path(), "path");
+/// # assert_eq!(&backend.path().to_string(), "path/tiles.pmtiles");
 ///
 /// // Or with URLs that encode the bucket name in the URL path
 /// let url = Url::parse("https://ACCOUNT_ID.r2.cloudflarestorage.com/bucket/path").unwrap();
 /// let backend = ObjectStoreBackend::try_from(&url).unwrap();
-/// # assert_eq!(&backend.path(), "path");
+/// # assert_eq!(&backend.path().to_string(), "path");
 /// ```
 ///
 /// Creating a backend manually:

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -1,0 +1,189 @@
+//! Object store backend implementation using the [`object_store`] crate.
+//!
+//! This backend provides a unified interface for accessing `PMTiles` from various
+//! storage systems including Files, HTTP, S3, Azure Blob Storage, and Google Cloud Storage.
+
+use std::ops::Range;
+
+use bytes::Bytes;
+use object_store::ObjectStore;
+use object_store::path::Path;
+use url::Url;
+
+use crate::{AsyncBackend, PmtError, PmtResult};
+
+/// Backend implementation using the [`object_store`] crate for unified storage access.
+///
+/// This backend can work with any storage system supported by [`object_store`]:
+/// - [AWS S3](https://aws.amazon.com/s3/) via `object-store-aws` feature
+/// - [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/) via `object-store-azure` feature
+/// - [Google Cloud Storage](https://cloud.google.com/storage) via `object-store-gcp` feature
+/// - Local files via `object-store-fs` feature
+/// - [HTTP/WebDAV Storage](https://datatracker.ietf.org/doc/html/rfc2518) via `object-store-http` feature
+/// - (mostly for testing) Memory
+/// - Custom implementations
+///
+/// # Examples
+///
+/// Creating a backend from a URL using `try_from`:
+/// ```rust
+/// # use pmtiles::ObjectStoreBackend;
+/// # use url::Url;
+/// #
+/// // Create from any supported URL scheme
+/// // For example http  (under object-store-http feature)
+/// let url = Url::parse("https://example.com/tiles.pmtiles").unwrap();
+/// let backend = ObjectStoreBackend::try_from(&url).unwrap();
+/// # assert_eq!(&backend.path(), "tiles.pmtiles");
+///
+/// // Works with S3 URLs too (under object-store-aws feature)
+/// let url = Url::parse("s3://bucket-name/path/tiles.pmtiles").unwrap();
+/// let backend = ObjectStoreBackend::try_from(&url).unwrap();
+/// # assert_eq!(&backend.path(), "path");
+///
+/// // Or with URLs that encode the bucket name in the URL path
+/// let url = Url::parse("https://ACCOUNT_ID.r2.cloudflarestorage.com/bucket/path").unwrap();
+/// let backend = ObjectStoreBackend::try_from(&url).unwrap();
+/// # assert_eq!(&backend.path(), "path");
+/// ```
+///
+/// Creating a backend manually:
+/// ```rust
+/// # #[cfg(feature = "object-store-http")]
+/// # {
+/// let store = Box::new(
+///     object_store::http::HttpBuilder::new()
+///         .with_url("https://example.com")
+///         .build()
+///         .unwrap()
+/// );
+/// let backend = pmtiles::ObjectStoreBackend::new(store, "tiles.pmtiles");
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct ObjectStoreBackend {
+    store: Box<dyn ObjectStore>,
+    path: Path,
+}
+
+impl ObjectStoreBackend {
+    /// Create a new [`ObjectStoreBackend`].
+    ///
+    /// # Arguments
+    /// * `store` - An object store implementation
+    /// * `path` - Path to the file within the store
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// # #[cfg(feature = "object-store-http")]
+    /// # {
+    /// use object_store::http::HttpBuilder;
+    /// use pmtiles::ObjectStoreBackend;
+    /// use std::sync::Arc;
+    ///
+    /// let store = Arc::new(
+    ///     HttpBuilder::new()
+    ///         .with_url("https://example.com")
+    ///         .build()
+    ///         .unwrap()
+    /// );
+    /// let backend = ObjectStoreBackend::new(store, "tiles.pmtiles");
+    /// # }
+    /// ```
+    ///
+    /// For convenience, you can also create backends directly from URLs:
+    /// ```rust,ignore
+    /// # #[cfg(feature = "object-store-http")]
+    /// # {
+    /// use pmtiles::ObjectStoreBackend;
+    /// use url::Url;
+    ///
+    /// let url = Url::parse("https://example.com/tiles.pmtiles").unwrap();
+    /// let backend = ObjectStoreBackend::try_from(&url).unwrap();
+    /// # }
+    /// ```
+    pub fn new<P: Into<Path>>(store: Box<dyn ObjectStore>, path: P) -> Self {
+        Self {
+            store,
+            path: path.into(),
+        }
+    }
+
+    /// Reference to the underlying object store.
+    #[must_use]
+    pub fn store(&self) -> &dyn ObjectStore {
+        &self.store
+    }
+
+    /// The path to the file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AsyncBackend for ObjectStoreBackend {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+        let range = Range {
+            start: offset as u64,
+            end: offset as u64 + length as u64,
+        };
+
+        let result = self.store.get_range(&self.path, range).await?;
+
+        Ok(result)
+    }
+}
+
+impl TryFrom<&Url> for ObjectStoreBackend {
+    type Error = PmtError;
+
+    fn try_from(value: &Url) -> Result<Self, Self::Error> {
+        let (store, path) = object_store::parse_url(value)?;
+        Ok(ObjectStoreBackend { store, path })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::memory::InMemory;
+
+    use super::*;
+
+    #[test]
+    fn test_new_backend() {
+        let store = Box::new(InMemory::new());
+        let backend = ObjectStoreBackend::new(store, "test.pmtiles");
+
+        assert_eq!(backend.path().as_ref(), "test.pmtiles");
+    }
+
+    #[tokio::test]
+    async fn test_error_conversion() {
+        let store = Box::new(InMemory::new());
+        let backend = ObjectStoreBackend::new(store, "nonexistent.pmtiles");
+
+        let result = backend.read(0, 100).await;
+        assert!(result.is_err());
+
+        // Verify it converts to the right error type
+        match result.unwrap_err() {
+            PmtError::ObjectStore(object_store::Error::NotFound { .. }) => {
+                // Expected error type
+            }
+            _ => panic!("Expected ObjectStore NotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn basic_http_test() {
+        let url_http =
+            Url::parse("https://protomaps.github.io/PMTiles/protomaps(vector)ODbL_firenze.pmtiles")
+                .unwrap();
+        let backend = ObjectStoreBackend::try_from(&url_http).unwrap();
+        assert_eq!(
+            backend.path().as_ref(),
+            "PMTiles/protomaps(vector)ODbL_firenze.pmtiles"
+        );
+    }
+}

--- a/src/backend_object_store.rs
+++ b/src/backend_object_store.rs
@@ -238,7 +238,7 @@ mod tests {
         let opts = [("user_agent", "pmties"), ("allow_http", "true")];
         let backend = ObjectStoreBackend::try_from((&url, opts)).unwrap();
         assert_eq!(backend.path().as_ref(), "foo/bar");
-        backend.store().get(&backend.path()).await.unwrap();
+        backend.store().get(backend.path()).await.unwrap();
 
         server.assert_hits(1);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,9 @@ pub enum PmtError {
     AwsS3Request(
         #[from] Box<aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>>,
     ),
+    #[cfg(feature = "object-store")]
+    #[error(transparent)]
+    ObjectStore(#[from] object_store::Error),
     #[error("Invalid coordinate {0}/{1}/{2}")]
     InvalidCoordinate(u8, u32, u32),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,6 @@ pub use directory::{DirEntry, Directory};
 pub use error::{PmtError, PmtResult};
 pub use header::{Compression, Header, TileType};
 /// Re-export of crate exposed in our API to simplify dependency management
-#[cfg(feature = "object-store")]
-pub use object_store;
-/// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "http-async")]
 pub use reqwest;
 /// Re-export of crate exposed in our API to simplify dependency management

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod backend_aws_s3;
 mod backend_http;
 #[cfg(feature = "mmap-async-tokio")]
 mod backend_mmap;
+#[cfg(feature = "object-store")]
+mod backend_object_store;
 #[cfg(feature = "__async-s3")]
 mod backend_s3;
 
@@ -35,6 +37,8 @@ pub use backend_aws_s3::AwsS3Backend;
 pub use backend_http::HttpBackend;
 #[cfg(feature = "mmap-async-tokio")]
 pub use backend_mmap::MmapBackend;
+#[cfg(feature = "object-store")]
+pub use backend_object_store::ObjectStoreBackend;
 #[cfg(feature = "__async-s3")]
 pub use backend_s3::S3Backend;
 #[cfg(feature = "iter-async")]
@@ -42,6 +46,9 @@ pub use directory::DirEntryCoordsIter;
 pub use directory::{DirEntry, Directory};
 pub use error::{PmtError, PmtResult};
 pub use header::{Compression, Header, TileType};
+/// Re-export of crate exposed in our API to simplify dependency management
+#[cfg(feature = "object-store")]
+pub use object_store;
 /// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "http-async")]
 pub use reqwest;


### PR DESCRIPTION
I have tried to be as throughogh in the testing as I could.
Unfortunately, there is not much of an existing testing infrastructure that I can rely upon in terms of sample data on cloud buckets (duh..).

So at first, this is a quite simple api that I think covers most usecases that one could have with this.

Yes, this allows for massive simplification in the other backends, but this should be a different PR with actual benchmarking how much impact the `Box<dyn>` dereference has compared to just accessing the file/mmap/http/s3 clients directly.

If there are any changes, benchmarks or tests that you would like to see, please tell me 🤙🏻

Related to (but not resolving) https://github.com/stadiamaps/pmtiles-rs/issues/42