### PR TITLE
Add an add_raw_tile that skips tile compression

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -193,7 +193,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     /// Add a pre-compressed tile to the writer.
     ///
     /// Use this method only if you want to manage the compression aspects before storing the tile.
-    /// Otherwise you should use [`add_tile`](Self::add_tile) instead.
+    /// Otherwise, you should use [`add_tile`](Self::add_tile) instead.
     ///
     /// Tiles are deduplicated and written to output.
     /// The `tile_id` generated from `z/x/y` should be increasing for best read performance.


### PR DESCRIPTION
I'm doing some multithreaded tile processing, and I ran in to a bottleneck when writing tiles to the archive. Because writing tiles can't be parallelized, it's much faster (20x faster on my setup) to add the compress step to the multithreaded pipeline, then write the bytes serially.