### PR TITLE
Writer tile dedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio"]
 s3-async-native = ["__async-s3", "__async-s3-nativetls"]
 s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
-write = ["dep:countio", "dep:flate2"]
+write = ["dep:blake3", "dep:countio", "dep:flate2"]
 
 object-store = ["dep:object_store"]
 
@@ -57,6 +57,7 @@ __async-aws-s3 = ["__async", "dep:aws-sdk-s3"]
 async-compression = { version = "0.4", features = ["gzip"] }
 async-stream = { version = "0.3", optional = true }
 aws-sdk-s3 = { version = "1.49.0", optional = true }
+blake3 = { version = "1.8", optional = true }
 bytes = "1"
 countio = { version = "0.2.19", optional = true }
 fast_hilbert = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio"]
 s3-async-native = ["__async-s3", "__async-s3-nativetls"]
 s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
 tilejson = ["dep:tilejson", "dep:serde", "dep:serde_json"]
-write = ["dep:blake3", "dep:countio", "dep:flate2"]
+write = ["dep:countio", "dep:flate2", "dep:twox-hash"]
 
 object-store = ["dep:object_store"]
 
@@ -57,7 +57,6 @@ __async-aws-s3 = ["__async", "dep:aws-sdk-s3"]
 async-compression = { version = "0.4", features = ["gzip"] }
 async-stream = { version = "0.3", optional = true }
 aws-sdk-s3 = { version = "1.49.0", optional = true }
-blake3 = { version = "1.8", optional = true }
 bytes = "1"
 countio = { version = "0.2.19", optional = true }
 fast_hilbert = "2.0.1"
@@ -72,6 +71,7 @@ serde_json = { version = "1", optional = true }
 thiserror = "2"
 tilejson = { version = "0.4", optional = true }
 tokio = { version = "1", default-features = false, features = ["io-util"], optional = true }
+twox-hash = { version = "2", optional = true, default-features = false, features = ["std", "xxhash3_64"] }
 varint-rs = "2"
 
 [dev-dependencies]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -461,7 +461,6 @@ mod tests {
         assert_eq!(header_in.n_addressed_tiles, header_out.n_addressed_tiles);
         assert_eq!(header_in.n_tile_entries, header_out.n_tile_entries);
         assert_eq!(header_in.n_tile_contents, header_out.n_tile_contents);
-        // assert_eq!(Some(84), header_out.n_tile_contents.map(Into::into));
         assert_eq!(header_in.min_zoom, header_out.min_zoom);
         assert_eq!(header_in.max_zoom, header_out.max_zoom);
         assert_eq!(header_in.center_zoom, header_out.center_zoom);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -244,19 +244,18 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
         self.n_addressed_tiles += 1;
 
         // If the tile is identical to the previous one and the tile_id is consecutive, increase run_length
-        if let Some(ref mut last_entry) = last_entry
-            && self.prev_tile_hash == Some(tile_hash)
-            && tile_id == last_entry.tile_id + u64::from(last_entry.run_length)
-        {
-            last_entry.run_length += 1;
-            return Ok(());
-        }
+        if let Some(ref mut last_entry) = last_entry {
+            if self.prev_tile_hash == Some(tile_hash)
+                && tile_id == last_entry.tile_id + u64::from(last_entry.run_length)
+            {
+                last_entry.run_length += 1;
+                return Ok(());
+            }
 
-        // If the tile_id is not in order, mark as unclustered
-        if let Some(last_entry) = last_entry
-            && tile_id < last_entry.tile_id + u64::from(last_entry.run_length)
-        {
-            self.header.clustered = false;
+            // If the tile_id is not in order, mark as unclustered
+            if tile_id < last_entry.tile_id + u64::from(last_entry.run_length) {
+                self.header.clustered = false;
+            }
         }
 
         // Based on the tile hash, either get the existing location or write the tile data to the archive


### PR DESCRIPTION
Deduplicates tiles based on their xxHash3 hash value.

I've looked at the spec and how go-pmtiles does it, and I've also set the "clustered" flag to mean "no unordered tiles", instead of "completely contiguous directories". This mainly makes it possible to have archives labeled as "clustered" when the tileset doesn't span the whole globe

Builds on #75 (that one should be merged first before merging this - let me know if you want me to roll these writer PRs up in to a larger PR).