### PR TITLE
Add `extract` functionality 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 temp/
 tmp/
 venv/
+*.pmtiles
 
 # This is a library, no lock
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.88"
 # In the future, we might want to change this to a more selective set of features.
 default = ["__all_non_conflicting"]
 aws-s3-async = ["__async-aws-s3"]
-extract = ["write", "dep:roaring", "dep:futures-util", "iter-async"]
-http-async = ["__async", "dep:reqwest"]
+extract = ["write", "dep:roaring", "dep:futures-util", "iter-async", "reqwest?/stream"]
+http-async = ["__async", "dep:reqwest", "dep:async-stream", "dep:futures-util"]
 iter-async = ["__async", "dep:async-stream", "dep:futures-util"]
 mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio"]
 moka = ["__async", "dep:moka"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.88"
 # In the future, we might want to change this to a more selective set of features.
 default = ["__all_non_conflicting"]
 aws-s3-async = ["__async-aws-s3"]
+extract = ["write", "dep:roaring", "dep:futures-util", "iter-async"]
 http-async = ["__async", "dep:reqwest"]
 iter-async = ["__async", "dep:async-stream", "dep:futures-util"]
 mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio"]
@@ -40,6 +41,7 @@ reqwest-webpki-roots = ["reqwest?/webpki-roots"]
 # This list excludes these conflicting features: s3-async-native
 __all_non_conflicting = [
     "aws-s3-async",
+    "extract",
     "http-async",
     "iter-async",
     "mmap-async-tokio",
@@ -70,9 +72,11 @@ fast_hilbert = "2.0.1"
 flate2 = { version = "1", optional = true }
 fmmap = { version = "0.4", default-features = false, optional = true }
 futures-util = { version = "0.3", optional = true }
+log = "0.4"
 moka = { version = "0.12", optional = true, features = ["future"] }
 object_store = { version = "0.13", optional = true, default-features = false }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
+roaring = { version = "0.10", optional = true }
 rust-s3 = { version = "0.37.0", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -22,10 +22,10 @@ use crate::{DirectoryCache, NoCache};
 
 /// An asynchronous reader for `PMTiles` archives.
 pub struct AsyncPmTilesReader<B, C = NoCache> {
-    backend: B,
+    pub(crate) backend: B,
     cache: C,
     header: Header,
-    root_directory: Directory,
+    pub(crate) root_directory: Directory,
 }
 
 impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B, NoCache> {
@@ -294,7 +294,11 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         Ok(entry)
     }
 
-    async fn read_directory(&self, offset: usize, length: usize) -> PmtResult<Directory> {
+    pub(crate) async fn read_directory(
+        &self,
+        offset: usize,
+        length: usize,
+    ) -> PmtResult<Directory> {
         let data = self.backend.read_exact(offset, length).await?;
         Self::read_compressed_directory(self.header.internal_compression, data).await
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::num::TryFromIntError;
 use std::string::FromUtf8Error;
 
 use thiserror::Error;
@@ -94,4 +95,8 @@ pub enum PmtError {
     /// Indicates an error occurred with the directory cache.
     #[error("An error occurred with the directory cache: {0}")]
     DirectoryCacheError(String),
+    /// Overflow when computing which chunks to read during archive extraction.
+    /// This could happen due to a malformed header or a large file on a 32bit system
+    #[error("System cannot read files this large or header is corrupt")]
+    IoRangeOverflow(TryFromIntError),
 }

--- a/src/extract/bbox.rs
+++ b/src/extract/bbox.rs
@@ -1,0 +1,109 @@
+// Bounding box utilities for extraction
+
+use roaring::RoaringTreemap;
+
+use crate::PmtResult;
+use crate::tile::{TileCoord, TileId};
+
+/// A geographic bounding box in WGS84 coordinates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoundingBox {
+    /// Maximum latitude (north) in degrees (-90 to 90)
+    pub max_lat: f64,
+    /// Maximum longitude (east) in degrees (-180 to 180)
+    pub max_lon: f64,
+    /// Minimum latitude (south) in degrees (-90 to 90)
+    pub min_lat: f64,
+    /// Minimum longitude (west) in degrees (-180 to 180)
+    pub min_lon: f64,
+}
+
+impl BoundingBox {
+    /// Creates a bounding box from North, East, South, West coordinates.
+    #[must_use]
+    pub fn from_nesw(north: f64, east: f64, south: f64, west: f64) -> Self {
+        Self {
+            max_lat: north,
+            max_lon: east,
+            min_lat: south,
+            min_lon: west,
+        }
+    }
+
+    /// Creates a bitmap containing all tiles that intersect with the bounding box
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the coordinates are out of bounds.
+    pub fn tile_bitmap(&self, min_zoom: u8, max_zoom: u8) -> PmtResult<RoaringTreemap> {
+        let mut bitmap = RoaringTreemap::new();
+
+        // Add tiles at max_zoom that intersect the bbox
+        // min_lat/max_lat need to be swapped because y increases southward
+        let min_tile = TileCoord::from_lon_lat_zoom(self.min_lon, self.max_lat, max_zoom)?;
+        let max_tile = TileCoord::from_lon_lat_zoom(self.max_lon, self.min_lat, max_zoom)?;
+
+        // Add all tiles in the rectangle at max_zoom
+        for x in min_tile.x()..=max_tile.x() {
+            for y in min_tile.y()..=max_tile.y() {
+                if let Ok(coord) = TileCoord::new(max_zoom, x, y) {
+                    let tile_id = TileId::from(coord).value();
+                    bitmap.insert(tile_id);
+                }
+            }
+        }
+
+        // Generalize: add parent tiles down to min_zoom
+        generalize_or(&mut bitmap, min_zoom)?;
+
+        Ok(bitmap)
+    }
+}
+
+/// Add parent tiles to the bitmap down to `min_zoom`.
+/// Port of generalizeOr from go-pmtiles/pmtiles/bitmap.go:42
+fn generalize_or(bitmap: &mut RoaringTreemap, min_zoom: u8) -> PmtResult<()> {
+    if bitmap.is_empty() {
+        return Ok(());
+    }
+
+    // Find max zoom from the highest tile ID
+    let max_tile_id = bitmap.max().expect("bitmap not empty");
+    let max_coord = TileCoord::from(TileId::new(max_tile_id)?);
+    let max_z = max_coord.z();
+
+    let mut temp = RoaringTreemap::new();
+    let mut to_iterate = bitmap.clone();
+
+    // Work backwards from max zoom to min_zoom, adding parents
+    for _current_z in min_zoom..max_z {
+        temp.clear();
+
+        for tile_id in &to_iterate {
+            let Some(parent_id) = TileId::new(tile_id)?.parent_id() else {
+                continue;
+            };
+            temp.insert(parent_id.value());
+        }
+
+        to_iterate.clone_from(&temp);
+        *bitmap |= &temp;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bbox_to_bitmap() {
+        // Small bbox should produce some tiles
+        let bbox = BoundingBox::from_nesw(37.8, -122.4, 37.7, -122.5);
+        let bitmap = bbox.tile_bitmap(10, 12).unwrap();
+
+        assert!(!bitmap.is_empty());
+        // Should have tiles at zoom 10, 11, and 12
+        assert!(!bitmap.is_empty());
+    }
+}

--- a/src/extract/extractor.rs
+++ b/src/extract/extractor.rs
@@ -1,0 +1,409 @@
+use std::io::{BufWriter, SeekFrom};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use countio::Counter;
+use futures_util::stream::{StreamExt, TryStreamExt};
+use tokio::sync::RwLock;
+
+use crate::async_reader::{AsyncBackend, AsyncPmTilesReader};
+use crate::extract::{BoundingBox, ExtractStats, ExtractionPlan};
+use crate::header::HEADER_SIZE;
+use crate::{DirectoryCache, Header, PmtError, PmtResult};
+
+/// Progress callback receiving a value between 0.0 and 1.0.
+pub type ExtractProgressCallback = dyn Fn(f64) + Send + Sync;
+
+/// Builder for extracting a subset of tiles from a `PMTiles` archive.
+pub struct Extractor<'a, 'b, B, C> {
+    reader: &'a AsyncPmTilesReader<B, C>,
+
+    min_zoom: Option<u8>,
+    max_zoom: Option<u8>,
+
+    /// Overfetch ratio (0.0-1.0). Higher values trade bandwidth for fewer requests.
+    overfetch: f32,
+
+    /// Number of concurrent requests for fetching data.
+    concurrency: usize,
+
+    progress: Option<&'b ExtractProgressCallback>,
+}
+
+impl<'a, B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> Extractor<'a, '_, B, C> {
+    /// Creates a new extractor.
+    pub fn new(reader: &'a AsyncPmTilesReader<B, C>) -> Self {
+        Self {
+            reader,
+            min_zoom: None,
+            max_zoom: None,
+            overfetch: 0.05,
+            concurrency: 4,
+            progress: None,
+        }
+    }
+
+    /// Sets the minimum zoom level to extract (inclusive).
+    ///
+    /// If not set, the archive's minimum zoom level will be used.
+    #[must_use]
+    pub fn min_zoom(mut self, min_zoom: u8) -> Self {
+        self.min_zoom = Some(min_zoom);
+        self
+    }
+
+    /// Sets the maximum zoom level to extract (inclusive).
+    ///
+    /// If not set, the archive's maximum zoom level will be used.
+    #[must_use]
+    pub fn max_zoom(mut self, max_zoom: u8) -> Self {
+        self.max_zoom = Some(max_zoom);
+        self
+    }
+
+    /// Sets the overfetch parameter for range merging (0.0 - 1.0).
+    ///
+    /// Higher values allow downloading more unused data to reduce the number of HTTP requests.
+    /// Default is 0.05 (5%).
+    #[must_use]
+    pub fn overfetch(mut self, overfetch: f32) -> Self {
+        self.overfetch = overfetch;
+        self
+    }
+
+    /// Sets the number of concurrent requests for fetching data.
+    ///
+    /// Default is 4.
+    #[must_use]
+    pub fn concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
+    /// Sets a progress callback that will be invoked periodically during extraction.
+    ///
+    /// The callback receives a value between 0.0 and 1.0 indicating completion progress.
+    pub fn progress<'c>(self, progress: &'c ExtractProgressCallback) -> Extractor<'a, 'c, B, C> {
+        Extractor {
+            max_zoom: self.max_zoom,
+            min_zoom: self.min_zoom,
+            overfetch: self.overfetch,
+            concurrency: self.concurrency,
+            reader: self.reader,
+            progress: Some(progress),
+        }
+    }
+
+    /// Returns the header from the source `PMTiles` archive.
+    #[must_use]
+    pub fn input_header(&self) -> &Header {
+        self.reader.get_header()
+    }
+
+    /// Port of Extract from go-pmtiles/pmtiles/extract.go:252
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if extraction fails.
+    pub async fn extract_bbox_to_writer<W: std::io::Write + std::io::Seek>(
+        &self,
+        bbox: BoundingBox,
+        output: &mut W,
+    ) -> PmtResult<ExtractStats> {
+        let extraction_plan = self.prepare(bbox).await?;
+        self.extract_to_writer(extraction_plan, output).await
+    }
+
+    /// Prepare an extraction by determining which tiles are needed.
+    ///
+    /// Reads the header and traverses the index, telling you which tiles you'll need
+    /// and how big the extract will be.
+    ///
+    /// # Arguments
+    ///
+    /// * `bbox` - Geographic bounding box defining the region to extract
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the archive is not clustered or if reading fails.
+    pub async fn prepare(&self, bbox: BoundingBox) -> PmtResult<ExtractionPlan> {
+        use crate::extract::{merge_ranges, reencode_entries, relevant_entries};
+
+        self.report_progress(0.0);
+        if !self.input_header().clustered {
+            return Err(PmtError::InvalidHeader);
+        }
+
+        let min_zoom = self
+            .min_zoom
+            .unwrap_or(self.input_header().min_zoom)
+            .max(self.input_header().min_zoom);
+        let max_zoom = self
+            .max_zoom
+            .unwrap_or(self.input_header().max_zoom)
+            .min(self.input_header().max_zoom);
+        if min_zoom > max_zoom {
+            return Err(PmtError::InvalidHeader);
+        }
+
+        let relevance_bitmap = bbox.tile_bitmap(min_zoom, max_zoom)?;
+        log::debug!("Relevant tiles: {}", relevance_bitmap.len());
+
+        let root_entries = &self.reader.root_directory.entries;
+        let (mut tile_entries, leaf_entries) =
+            relevant_entries(&relevance_bitmap, max_zoom, root_entries);
+        log::debug!(
+            "Root directory: {} tile entries, {} leaf entries",
+            tile_entries.len(),
+            leaf_entries.len()
+        );
+
+        // Fetch and process leaf directories in parallel (with concurrency limit)
+        let num_leaf_entries = leaf_entries.len();
+        let completed_requests = Arc::new(RwLock::new(0));
+        let leaf_dirs: Vec<crate::Directory> =
+            futures_util::stream::iter(leaf_entries.into_iter().enumerate().map(
+                |(idx, leaf_entry)| {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let offset = (self.input_header().leaf_offset + leaf_entry.offset) as usize;
+                    let length = leaf_entry.length as usize;
+                    let completed_requests = completed_requests.clone();
+                    async move {
+                        log::debug!(
+                            "Reading leaf directory {}/{}: offset={}, length={}",
+                            idx + 1,
+                            num_leaf_entries,
+                            offset,
+                            length
+                        );
+                        let result = self.reader.read_directory(offset, length).await;
+                        let progress_complete = {
+                            let mut completed_requests = completed_requests.write().await;
+                            *completed_requests += 1;
+                            #[allow(clippy::cast_precision_loss)]
+                            {
+                                f64::from(*completed_requests) / num_leaf_entries as f64
+                            }
+                        };
+                        self.report_progress(progress_complete);
+                        result
+                    }
+                },
+            ))
+            .buffered(self.concurrency)
+            .try_collect()
+            .await?;
+
+        for leaf_dir in leaf_dirs {
+            let (new_tiles, _new_leaves) =
+                relevant_entries(&relevance_bitmap, max_zoom, &leaf_dir.entries);
+            log::debug!("  Found {} relevant tiles in this leaf", new_tiles.len());
+            tile_entries.extend(new_tiles);
+        }
+
+        log::debug!("Total tiles to extract: {}", tile_entries.len());
+
+        tile_entries.sort_by_key(|e| e.tile_id);
+        let (reencoded_entries, tile_ranges, tile_data_length, addressed_tiles, tile_contents) =
+            reencode_entries(tile_entries);
+        let (overfetch_ranges, total_tile_transfer_bytes) =
+            merge_ranges(&tile_ranges, self.overfetch);
+
+        self.report_progress(1.0);
+
+        let num_tile_reqs = overfetch_ranges.len();
+        Ok(ExtractionPlan {
+            reencoded_entries,
+            overfetch_ranges,
+            stats: ExtractStats {
+                min_zoom,
+                max_zoom,
+                bbox,
+                total_tile_transfer_bytes,
+                tile_data_length,
+                addressed_tiles,
+                tile_contents,
+                num_leaf_entries,
+                num_tile_reqs,
+            },
+        })
+    }
+
+    /// Port of Extract from go-pmtiles/pmtiles/extract.go:252
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing fails or if fetching tile data fails.
+    #[allow(clippy::too_many_lines)]
+    pub async fn extract_to_writer<W: std::io::Write + std::io::Seek>(
+        &self,
+        mut plan: ExtractionPlan,
+        mut output: &mut W,
+    ) -> PmtResult<ExtractStats> {
+        use crate::directory::MAX_ROOT_DIR_BYTES;
+        use crate::writer::WriteTo;
+        // Use source compression
+        let compression = self.input_header().internal_compression;
+
+        // Build new directories (optimize into root + leaves if needed)
+        let reencoded_entries_len = plan.reencoded_entries.len();
+        let (new_root, new_leaves) = crate::directory::optimize_directories(
+            std::mem::take(&mut plan.reencoded_entries),
+            MAX_ROOT_DIR_BYTES,
+            compression,
+        )?;
+
+        let metadata_bytes = match self.input_header().metadata_length {
+            0 => Bytes::new(),
+            len => {
+                #[allow(clippy::cast_possible_truncation)]
+                let offset = self.input_header().metadata_offset as usize;
+                #[allow(clippy::cast_possible_truncation)]
+                let len = len as usize;
+                self.backend().read_exact(offset, len).await?
+            }
+        };
+
+        let mut new_header = self.input_header().clone();
+
+        new_header.min_zoom = plan.min_zoom();
+        new_header.max_zoom = plan.max_zoom();
+
+        let bbox = plan.bbox();
+        new_header.min_longitude = bbox.min_lon;
+        new_header.min_latitude = bbox.min_lat;
+        new_header.max_longitude = bbox.max_lon;
+        new_header.max_latitude = bbox.max_lat;
+        new_header.center_longitude = f64::midpoint(bbox.min_lon, bbox.max_lon);
+        new_header.center_latitude = f64::midpoint(bbox.min_lat, bbox.max_lat);
+        new_header.center_zoom = plan.min_zoom();
+
+        new_header.internal_compression = compression;
+
+        // Update tile counts
+        new_header.n_addressed_tiles = std::num::NonZeroU64::new(plan.addressed_tiles());
+        new_header.n_tile_entries = std::num::NonZeroU64::new(reencoded_entries_len as u64);
+        new_header.n_tile_contents = std::num::NonZeroU64::new(plan.tile_contents());
+
+        // Write everything preceding the tile data
+        output.seek(SeekFrom::Start(HEADER_SIZE as u64))?;
+
+        let root_length =
+            new_root.write_compressed_to_counted(&mut Counter::new(&mut output), compression)?;
+        new_header.root_length = root_length as u64;
+        output.write_all(&metadata_bytes)?;
+        let mut leaf_length = 0;
+        for leaf in new_leaves {
+            leaf_length += leaf.write_compressed_to_counted(
+                &mut Counter::new(BufWriter::new(&mut output)),
+                compression,
+            )?;
+        }
+        new_header.leaf_length = leaf_length as u64;
+
+        // Update offsets
+        new_header.root_offset = HEADER_SIZE as u64;
+        new_header.metadata_offset = new_header.root_offset + new_header.root_length;
+        new_header.leaf_offset = new_header.metadata_offset + new_header.metadata_length;
+        new_header.data_offset = new_header.leaf_offset + new_header.leaf_length;
+        new_header.data_length = plan.tile_data_length();
+
+        // Pop back to the beginning now that we have the header offsets
+        {
+            let current_pos = output.stream_position()?;
+            output.rewind()?;
+            new_header.write_to(&mut output)?;
+            output.seek(SeekFrom::Start(current_pos))?;
+        }
+
+        // Fetch and write tile data using merged ranges
+        #[allow(clippy::cast_precision_loss)]
+        {
+            log::debug!(
+                "Fetching tile data: {} requests, {} bytes total ({} actual tiles, {:.1}% overfetch)",
+                plan.overfetch_ranges().len(),
+                plan.total_tile_transfer_bytes(),
+                plan.tile_data_length(),
+                if plan.tile_data_length() > 0 {
+                    ((plan.total_tile_transfer_bytes() - plan.tile_data_length()) as f64
+                        / plan.tile_data_length() as f64)
+                        * 100.0
+                } else {
+                    0.0
+                }
+            );
+        }
+
+        // Fetch tile ranges in parallel (with concurrency limit)
+        let total_request_count = plan.overfetch_ranges().len();
+        let completed_reqs_and_bytes = Arc::new(RwLock::new((0, 0)));
+        let output = Arc::new(RwLock::new(output));
+        let _results: Vec<()> = futures_util::stream::iter(
+            plan.overfetch_ranges()
+                .to_vec()
+                .into_iter()
+                .enumerate()
+                .map(|(idx, overfetch_range)| {
+                    let data_offset = self.input_header().data_offset;
+                    let completed_reqs_and_bytes = completed_reqs_and_bytes.clone();
+                    let output = output.clone();
+                    let total_tile_transfer_bytes = plan.total_tile_transfer_bytes();
+                    async move {
+                        let src_offset = try_into_usize(data_offset + overfetch_range.range.src_offset)?;
+                        let length = try_into_usize(overfetch_range.range.length)?;
+                        log::debug!(
+                                "Request {}/{total_request_count}: offset={src_offset}, length={length} bytes",
+                                idx + 1,
+                            );
+
+                        let bytes = self.backend().read_exact(src_offset, length).await?;
+
+                        // Write the fetched data to output
+                        let dst_offset = new_header.data_offset + overfetch_range.range.dst_offset;
+
+                        let mut output = output.write().await;
+                        output.seek(SeekFrom::Start(dst_offset))?;
+                        // Process copy/discard instructions - write wanted bytes, skip discard bytes
+                        let mut pos = 0;
+                        for cd in &overfetch_range.copy_discards {
+                            let wanted = try_into_usize(cd.wanted)?;
+                            let discard = try_into_usize(cd.discard)?;
+                            output.write_all(&bytes[pos..pos + wanted])?;
+                            pos += wanted + discard;
+                        }
+                        drop(output);
+
+                        #[allow(clippy::cast_precision_loss)]
+                        let progress_completed = {
+                            let mut completed_reqs_and_bytes = completed_reqs_and_bytes.write().await;
+                            completed_reqs_and_bytes.0 += 1;
+                            completed_reqs_and_bytes.1 += length;
+                            let req_ratio = f64::from(completed_reqs_and_bytes.0) / total_request_count as f64;
+                            let byte_ratio = completed_reqs_and_bytes.1 as f64 / total_tile_transfer_bytes as f64;
+                            req_ratio * 0.3 + byte_ratio * 0.7
+                        };
+                        self.report_progress(progress_completed);
+                        PmtResult::Ok(())
+                    }
+                })
+        )
+            .buffered(self.concurrency)
+            .try_collect()
+            .await?;
+        Ok(plan.stats)
+    }
+
+    fn backend(&self) -> &B {
+        &self.reader.backend
+    }
+
+    fn report_progress(&self, ratio_complete: f64) {
+        if let Some(progress) = &self.progress {
+            progress(ratio_complete);
+        }
+    }
+}
+
+fn try_into_usize(v: u64) -> PmtResult<usize> {
+    v.try_into().map_err(PmtError::IoRangeOverflow)
+}

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,0 +1,347 @@
+//! Extract subsets of tiles from `PMTiles` archives.
+//!
+//! Extracts tiles within a bounding box, optimizing network requests through range merging.
+//! Source archive must be **clustered** (tiles stored in Hilbert curve order).
+//!
+//! # Examples
+//!
+//! ## Extracting to a file
+//!
+//! ```no_run
+//! use pmtiles::extract::{BoundingBox, Extractor};
+//! use pmtiles::{AsyncPmTilesReader, MmapBackend};
+//! use std::fs::File;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Open source archive
+//! let backend = MmapBackend::try_from("source.pmtiles").await?;
+//! let mut reader = AsyncPmTilesReader::try_from_source(backend).await?;
+//!
+//! // Create extractor
+//! let extractor = Extractor::new(&mut reader);
+//!
+//! // Define bounding box (North, East, South, West)
+//! let bbox = BoundingBox::from_nesw(37.8, -122.4, 37.7, -122.5);
+//!
+//! // Extract to file
+//! let mut output = File::create("extracted.pmtiles")?;
+//! let stats = extractor.extract_bbox_to_writer(bbox, &mut output).await?;
+//!
+//! println!("Extracted {} tiles", stats.addressed_tiles());
+//! println!("Transferred {} bytes", stats.total_tile_transfer_bytes());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Checking extraction size before downloading
+//!
+//! ```no_run
+//! use pmtiles::extract::{BoundingBox, Extractor};
+//! use pmtiles::{AsyncPmTilesReader, MmapBackend};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Open source archive
+//! let backend = MmapBackend::try_from("source.pmtiles").await?;
+//! let mut reader = AsyncPmTilesReader::try_from_source(backend).await?;
+//!
+//! // Create extractor
+//! let extractor = Extractor::new(&mut reader);
+//!
+//! let bbox = BoundingBox::from_nesw(37.8, -122.4, 37.7, -122.5);
+//!
+//! // Get size estimate without fetching tiles
+//! let plan = extractor
+//!     .prepare(bbox)
+//!     .await?;
+//!
+//! println!("Would extract {} tiles using {} tile requests", plan.addressed_tiles(), plan.overfetch_ranges().len());
+//! println!("Would transfer {} bytes", plan.total_tile_transfer_bytes());
+//!
+//! // Only proceed if reasonable size
+//! if plan.total_tile_transfer_bytes() < 100_000_000 {
+//!     // Proceed with actual extraction...
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+mod bbox;
+mod ranges;
+
+mod extractor;
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+
+pub use bbox::BoundingBox;
+pub use extractor::{ExtractProgressCallback, Extractor};
+pub use ranges::{CopyDiscard, OverfetchRange, SrcDstRange, merge_ranges};
+use roaring::RoaringTreemap;
+
+use crate::{DirEntry, TileCoord, TileId};
+
+/// Extraction plan from analyzing bbox and directories.
+///
+/// This contains all the information needed to compute extraction size
+/// and perform the actual extraction.
+#[derive(Debug, Clone)]
+pub struct ExtractionPlan {
+    pub(crate) stats: ExtractStats,
+    pub(crate) reencoded_entries: Vec<DirEntry>,
+    pub(crate) overfetch_ranges: Vec<OverfetchRange>,
+}
+
+/// Statistics about an extraction operation.
+#[derive(Debug, Clone)]
+pub struct ExtractStats {
+    pub(crate) min_zoom: u8,
+    pub(crate) max_zoom: u8,
+    pub(crate) bbox: BoundingBox,
+    pub(crate) total_tile_transfer_bytes: u64,
+    pub(crate) tile_data_length: u64,
+    pub(crate) addressed_tiles: u64,
+    pub(crate) tile_contents: u64,
+    pub(crate) num_leaf_entries: usize,
+    pub(crate) num_tile_reqs: usize,
+}
+
+impl ExtractStats {
+    /// Total bytes transferred (includes overfetch)
+    #[must_use]
+    pub fn total_tile_transfer_bytes(&self) -> u64 {
+        self.total_tile_transfer_bytes
+    }
+
+    /// Actual tile data bytes used
+    #[must_use]
+    pub fn tile_data_length(&self) -> u64 {
+        self.tile_data_length
+    }
+
+    /// Number of unique tile contents
+    #[must_use]
+    pub fn tile_contents(&self) -> u64 {
+        self.tile_contents
+    }
+
+    /// Number of addressed tiles (reencoded entries)
+    #[must_use]
+    pub fn addressed_tiles(&self) -> u64 {
+        self.addressed_tiles
+    }
+
+    /// Number of overfetch ranges used for fetching
+    #[must_use]
+    pub fn num_tile_reqs(&self) -> usize {
+        self.num_tile_reqs
+    }
+}
+
+impl ExtractionPlan {
+    /// Re-encoded tile entries with new contiguous offsets
+    #[must_use]
+    pub fn reencoded_entries(&self) -> &[DirEntry] {
+        &self.reencoded_entries
+    }
+
+    /// Merged byte ranges for optimized fetching
+    #[must_use]
+    pub fn overfetch_ranges(&self) -> &[OverfetchRange] {
+        &self.overfetch_ranges
+    }
+
+    /// Minimum zoom level for extraction
+    #[must_use]
+    pub fn min_zoom(&self) -> u8 {
+        self.stats.min_zoom
+    }
+
+    /// Maximum zoom level for extraction
+    #[must_use]
+    pub fn max_zoom(&self) -> u8 {
+        self.stats.max_zoom
+    }
+
+    /// The bounding box that was extracted
+    #[must_use]
+    pub fn bbox(&self) -> BoundingBox {
+        self.stats.bbox
+    }
+
+    /// Total bytes to transfer (including overfetch)
+    #[must_use]
+    pub fn total_tile_transfer_bytes(&self) -> u64 {
+        self.stats.total_tile_transfer_bytes
+    }
+
+    /// Actual tile data bytes (excluding overfetch)
+    #[must_use]
+    pub fn tile_data_length(&self) -> u64 {
+        self.stats.tile_data_length
+    }
+
+    /// Number of addressed tiles (sum of run lengths)
+    #[must_use]
+    pub fn addressed_tiles(&self) -> u64 {
+        self.stats.addressed_tiles
+    }
+
+    /// Number of unique tile contents
+    #[must_use]
+    pub fn tile_contents(&self) -> u64 {
+        self.stats.tile_contents
+    }
+
+    /// Number of leaf directory entries read
+    #[must_use]
+    pub fn num_leaf_entries(&self) -> usize {
+        self.stats.num_leaf_entries
+    }
+}
+
+/// Filters directory entries to those intersecting the bitmap.
+///
+/// Returns `(tile_entries, leaf_entries)`.
+///
+/// # Panics
+///
+/// Panics if `max_zoom + 1` is not a valid tile coordinate.
+#[must_use]
+pub fn relevant_entries(
+    bitmap: &RoaringTreemap,
+    max_zoom: u8,
+    dir: &[DirEntry],
+) -> (Vec<DirEntry>, Vec<DirEntry>) {
+    // Calculate last tile ID for bounding leaf ranges
+    let last_tile = if max_zoom < 31 {
+        TileId::from(TileCoord::new(max_zoom + 1, 0, 0).expect("valid coord")).value()
+    } else {
+        // At max zoom, use max tile ID
+        crate::tile::MAX_TILE_ID
+    };
+
+    let mut leaves = Vec::new();
+    let mut tiles = Vec::new();
+
+    for (idx, entry) in dir.iter().enumerate() {
+        log::debug!("enumerating {idx}");
+        if entry.run_length == 0 {
+            let mut tmp = RoaringTreemap::new();
+
+            if let Some(next) = dir.get(idx + 1) {
+                tmp.insert_range(entry.tile_id..next.tile_id);
+            } else {
+                // Last entry - bounded by last_tile
+                tmp.insert_range(entry.tile_id..last_tile);
+            }
+
+            if bitmap.is_disjoint(&tmp) {
+                // No intersection
+                continue;
+            }
+            leaves.push(entry.clone());
+        } else if entry.run_length == 1 {
+            if bitmap.contains(entry.tile_id) {
+                tiles.push(entry.clone());
+            }
+        } else {
+            // Run length > 1
+            let mut current_id = entry.tile_id;
+            let mut current_run_length = 0_u32;
+
+            for tile_id in entry.tile_id..(entry.tile_id + u64::from(entry.run_length)) {
+                if bitmap.contains(tile_id) {
+                    if current_run_length == 0 {
+                        current_run_length = 1;
+                        current_id = tile_id;
+                    } else {
+                        current_run_length += 1;
+                    }
+                } else {
+                    if current_run_length > 0 {
+                        // End of a run
+                        tiles.push(DirEntry {
+                            tile_id: current_id,
+                            offset: entry.offset,
+                            length: entry.length,
+                            run_length: current_run_length,
+                        });
+                    }
+                    current_run_length = 0;
+                }
+            }
+
+            if current_run_length > 0 {
+                tiles.push(DirEntry {
+                    tile_id: current_id,
+                    offset: entry.offset,
+                    length: entry.length,
+                    run_length: current_run_length,
+                });
+            }
+        }
+    }
+
+    (tiles, leaves)
+}
+
+/// Re-encodes entries with contiguous offsets, deduplicating tiles.
+///
+/// Returns (`entries`, `ranges`, `tile_data_length`, `addressed_tiles`, `tile_contents`).
+///
+/// Based on <https://github.com/protomaps/go-pmtiles/blob/f1c24e64f3085877d57c8e0f07233e0a3ef25a99/pmtiles/extract.go#L93>
+#[must_use]
+pub fn reencode_entries(dir: Vec<DirEntry>) -> (Vec<DirEntry>, Vec<SrcDstRange>, u64, u64, u64) {
+    let mut reencoded = Vec::with_capacity(dir.len());
+    let mut seen_offsets: HashMap<u64, u64> = HashMap::new();
+    let mut ranges: Vec<SrcDstRange> = Vec::new();
+    let mut addressed_tiles = 0_u64;
+    let mut dst_offset = 0_u64;
+
+    for entry in dir {
+        addressed_tiles += u64::from(entry.run_length);
+
+        if let Some(&existing_dst_offset) = seen_offsets.get(&entry.offset) {
+            // We've seen this source offset before - reuse the destination offset (deduplication)
+            reencoded.push(DirEntry {
+                offset: existing_dst_offset,
+                ..entry
+            });
+        } else {
+            // New source offset - need to copy this data
+
+            // Check if we can merge with the previous range
+            if let Some(last) = ranges.last_mut()
+                && last.src_end() == entry.offset
+            {
+                last.length += u64::from(entry.length);
+            } else {
+                ranges.push(SrcDstRange {
+                    src_offset: entry.offset,
+                    dst_offset,
+                    length: u64::from(entry.length),
+                });
+            }
+
+            reencoded.push(DirEntry {
+                offset: dst_offset,
+                ..entry
+            });
+
+            seen_offsets.insert(entry.offset, dst_offset);
+            dst_offset += u64::from(entry.length);
+        }
+    }
+
+    let tile_data_length = dst_offset;
+    let tile_contents = seen_offsets.len() as u64;
+
+    (
+        reencoded,
+        ranges,
+        tile_data_length,
+        addressed_tiles,
+        tile_contents,
+    )
+}

--- a/src/extract/ranges.rs
+++ b/src/extract/ranges.rs
@@ -1,0 +1,282 @@
+// Port of MergeRanges from go-pmtiles/pmtiles/extract.go:159
+
+/// A range of bytes to copy from source to destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SrcDstRange {
+    /// Offset in the source file
+    pub src_offset: u64,
+    /// Offset in the destination file
+    pub dst_offset: u64,
+    /// Number of bytes to copy
+    pub length: u64,
+}
+
+impl SrcDstRange {
+    pub(crate) fn src_end(&self) -> u64 {
+        self.src_offset + self.length
+    }
+}
+
+/// Instructions for copying data with discards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyDiscard {
+    /// Number of bytes to keep
+    pub wanted: u64,
+    /// Number of bytes to skip
+    pub discard: u64,
+}
+
+/// A merged range that may include overfetch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverfetchRange {
+    /// The byte range to fetch
+    pub range: SrcDstRange,
+    /// Instructions for which bytes to copy and which to discard
+    pub copy_discards: Vec<CopyDiscard>,
+}
+
+#[derive(Debug, Clone)]
+struct MergeItem {
+    range: SrcDstRange,
+    bytes_to_next: u64,
+    copy_discards: Vec<CopyDiscard>,
+    prev: Option<usize>,
+    next: Option<usize>,
+}
+
+/// Merges ranges to minimize requests, trading bandwidth for fewer fetches.
+///
+/// Returns (`merged_ranges`, `total_bytes_transferred`).
+#[must_use]
+pub fn merge_ranges(ranges: &[SrcDstRange], overfetch: f32) -> (Vec<OverfetchRange>, u64) {
+    if ranges.is_empty() {
+        return (vec![], 0);
+    }
+
+    let mut total_size = 0_u64;
+    let mut items: Vec<MergeItem> = Vec::with_capacity(ranges.len());
+
+    // Create merge items with distance to next range
+    for (i, rng) in ranges.iter().enumerate() {
+        let bytes_to_next = if i == ranges.len() - 1 {
+            u64::MAX
+        } else {
+            let gap = ranges[i + 1]
+                .src_offset
+                .saturating_sub(rng.src_offset + rng.length);
+            if gap > 0 {
+                gap
+            } else {
+                // Ranges overlap or are not properly ordered by source - can't merge
+                u64::MAX
+            }
+        };
+
+        items.push(MergeItem {
+            range: *rng,
+            bytes_to_next,
+            copy_discards: vec![CopyDiscard {
+                wanted: rng.length,
+                discard: 0,
+            }],
+            prev: if i > 0 { Some(i - 1) } else { None },
+            next: if i < ranges.len() - 1 {
+                Some(i + 1)
+            } else {
+                None
+            },
+        });
+
+        total_size += rng.length;
+    }
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    let mut overfetch_budget = (total_size as f32 * overfetch) as i64;
+
+    // Create indices sorted by bytes_to_next (ascending)
+    let mut sorted_indices: Vec<usize> = (0..items.len()).collect();
+    sorted_indices.sort_by_key(|&i| items[i].bytes_to_next);
+
+    // Merge ranges while we have budget and multiple ranges
+    while sorted_indices.len() > 1 {
+        let idx = sorted_indices[0];
+        let item_bytes_to_next = items[idx].bytes_to_next;
+
+        // Can't merge if gap is too large (u64::MAX means can't merge)
+        if item_bytes_to_next == u64::MAX {
+            break;
+        }
+
+        #[expect(clippy::cast_possible_wrap)]
+        if overfetch_budget - (item_bytes_to_next as i64) < 0 {
+            break;
+        }
+
+        // Get the item to merge
+        let Some(next_idx) = items[idx].next else {
+            break; // No next item to merge into
+        };
+
+        // Merge current item into next item
+        let new_length =
+            items[idx].range.length + item_bytes_to_next + items[next_idx].range.length;
+        items[next_idx].range = SrcDstRange {
+            src_offset: items[idx].range.src_offset,
+            dst_offset: items[idx].range.dst_offset,
+            length: new_length,
+        };
+
+        // Update prev pointer of next item
+        items[next_idx].prev = items[idx].prev;
+
+        // Update next pointer of previous item (if exists)
+        if let Some(prev_idx) = items[idx].prev {
+            items[prev_idx].next = Some(next_idx);
+        }
+
+        // Update copy_discards: set discard on last element of current item
+        if let Some(last) = items[idx].copy_discards.last_mut() {
+            last.discard = item_bytes_to_next;
+        }
+
+        // Prepend current item's copy_discards to next item's
+        let mut new_copy_discards = items[idx].copy_discards.clone();
+        new_copy_discards.append(&mut items[next_idx].copy_discards);
+        items[next_idx].copy_discards = new_copy_discards;
+
+        // Remove merged item from sorted list
+        sorted_indices.remove(0);
+
+        #[expect(clippy::cast_possible_wrap)]
+        {
+            overfetch_budget -= item_bytes_to_next as i64;
+        }
+
+        // Re-sort (items have changed, need to re-sort)
+        sorted_indices.sort_by_key(|&i| items[i].bytes_to_next);
+    }
+
+    // Sort remaining items by descending length
+    sorted_indices.sort_by(|&a, &b| items[b].range.length.cmp(&items[a].range.length));
+
+    let mut total_bytes_transferred = 0_u64;
+    let merged_ranges: Vec<OverfetchRange> = sorted_indices
+        .into_iter()
+        .map(|i| {
+            total_bytes_transferred += items[i].range.length;
+            OverfetchRange {
+                range: items[i].range,
+                copy_discards: items[i].copy_discards.clone(),
+            }
+        })
+        .collect();
+
+    (merged_ranges, total_bytes_transferred)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_ranges() {
+        // Port of TestMergeRanges extract_test.go#L137
+        let ranges = vec![
+            SrcDstRange {
+                src_offset: 0,
+                dst_offset: 0,
+                length: 50,
+            },
+            SrcDstRange {
+                src_offset: 60,
+                dst_offset: 60,
+                length: 60,
+            },
+        ];
+
+        let (result, total_transfer_bytes) = merge_ranges(&ranges, 0.1);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(total_transfer_bytes, 120);
+        let front = &result[0];
+        assert_eq!(
+            front.range,
+            SrcDstRange {
+                src_offset: 0,
+                dst_offset: 0,
+                length: 120
+            }
+        );
+        assert_eq!(front.copy_discards.len(), 2);
+        assert_eq!(
+            front.copy_discards[0],
+            CopyDiscard {
+                wanted: 50,
+                discard: 10
+            }
+        );
+        assert_eq!(
+            front.copy_discards[1],
+            CopyDiscard {
+                wanted: 60,
+                discard: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_merge_ranges_multiple() {
+        // Port of TestMergeRangesMultiple extract_test.go#L154
+        let ranges = vec![
+            SrcDstRange {
+                src_offset: 0,
+                dst_offset: 0,
+                length: 50,
+            },
+            SrcDstRange {
+                src_offset: 60,
+                dst_offset: 60,
+                length: 10,
+            },
+            SrcDstRange {
+                src_offset: 80,
+                dst_offset: 80,
+                length: 10,
+            },
+        ];
+
+        let (result, total_transfer_bytes) = merge_ranges(&ranges, 0.3);
+        assert_eq!(total_transfer_bytes, 90);
+        assert_eq!(result.len(), 1);
+        let front = &result[0];
+        assert_eq!(
+            front.range,
+            SrcDstRange {
+                src_offset: 0,
+                dst_offset: 0,
+                length: 90
+            }
+        );
+        assert_eq!(front.copy_discards.len(), 3);
+    }
+
+    #[test]
+    fn test_merge_ranges_non_src_ordered() {
+        // Port of TestMergeRangesMultiple extract_test.go#L168
+        let ranges = vec![
+            SrcDstRange {
+                src_offset: 20,
+                dst_offset: 0,
+                length: 50,
+            },
+            SrcDstRange {
+                src_offset: 0,
+                dst_offset: 60,
+                length: 50,
+            },
+        ];
+
+        let (result, _) = merge_ranges(&ranges, 0.1);
+        assert_eq!(result.len(), 2);
+    }
+}

--- a/src/extract/tests/integration_tests.rs
+++ b/src/extract/tests/integration_tests.rs
@@ -1,0 +1,162 @@
+// Integration tests for extract functionality
+// Tests actual bbox extraction with fixtures
+
+use std::io::Cursor;
+
+use crate::extract::{BoundingBox, Extractor};
+use crate::header::HEADER_SIZE;
+use crate::{AsyncPmTilesReader, MmapBackend};
+
+#[tokio::test]
+async fn test_extract_firenze_small_bbox() {
+    // Port of: TestExtract (go-pmtiles/pmtiles/extract_test.go:80)
+    // Extract a small bbox from the Firenze fixture
+
+    // Open the source file
+    let backend = MmapBackend::try_from(crate::tests::VECTOR_FILE)
+        .await
+        .unwrap();
+    let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+
+    // Small bbox in the center of Florence
+    let bbox = BoundingBox::from_nesw(43.78, 11.26, 43.77, 11.24);
+
+    // Extract to memory
+    let mut output = Cursor::new(Vec::new());
+    let extractor = Extractor::new(&reader);
+    let stats = extractor
+        .extract_bbox_to_writer(bbox, &mut output)
+        .await
+        .unwrap();
+
+    // Verify we got some tiles
+    assert_eq!(stats.addressed_tiles(), 31);
+    assert_eq!(stats.tile_data_length(), 1_469_320);
+
+    // Verify the output is a valid PMTiles archive
+    let output_bytes = output.into_inner();
+    assert!(
+        output_bytes.len() >= HEADER_SIZE,
+        "Output should have header"
+    );
+    assert_eq!(&output_bytes[0..7], b"PMTiles", "Should have magic bytes");
+
+    // Write to temp file to test reading it back
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path().join("extracted.pmtiles");
+    std::fs::write(&temp_path, &output_bytes).unwrap();
+
+    // Try to read the extracted archive
+    let extracted_backend = MmapBackend::try_from(&temp_path).await.unwrap();
+    let extracted_reader = AsyncPmTilesReader::try_from_source(extracted_backend)
+        .await
+        .unwrap();
+
+    // Verify header properties
+    let header = extracted_reader.get_header();
+    assert!(header.clustered, "Extracted archive should be clustered");
+    assert_eq!(
+        stats.addressed_tiles(),
+        header.n_tile_entries.unwrap().get(),
+        "Plan entries should match header"
+    );
+}
+
+#[tokio::test]
+async fn test_extract_with_zoom_range() {
+    // Test extracting with specific zoom range
+    let backend = MmapBackend::try_from(crate::tests::VECTOR_FILE)
+        .await
+        .unwrap();
+    let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+
+    // Bbox covering most of Florence
+    let bbox = BoundingBox::from_nesw(43.83, 11.33, 43.73, 11.15);
+
+    let mut output = Cursor::new(Vec::new());
+    let extractor = Extractor::new(&reader).min_zoom(10).max_zoom(12);
+    let stats = extractor
+        .extract_bbox_to_writer(bbox, &mut output)
+        .await
+        .unwrap();
+
+    // Verify we got tiles
+    assert_eq!(stats.addressed_tiles(), 10);
+
+    let output_bytes = output.into_inner();
+
+    // Write to temp file to read back
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path().join("extracted.pmtiles");
+    std::fs::write(&temp_path, &output_bytes).unwrap();
+
+    let extracted_backend = MmapBackend::try_from(&temp_path).await.unwrap();
+    let extracted_reader = AsyncPmTilesReader::try_from_source(extracted_backend)
+        .await
+        .unwrap();
+
+    let header = extracted_reader.get_header();
+    assert!(header.min_zoom >= 10, "Min zoom should be at least 10");
+    assert!(header.max_zoom <= 12, "Max zoom should be at most 12");
+}
+
+#[tokio::test]
+async fn test_extract_overfetch_reduces_requests() {
+    let bbox = BoundingBox::from_nesw(43.80, 11.28, 43.75, 11.20);
+
+    // Extract with low overfetch
+    let stats_low = {
+        let backend = MmapBackend::try_from(crate::tests::VECTOR_FILE)
+            .await
+            .unwrap();
+        let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+
+        let mut output1 = Cursor::new(Vec::new());
+        let extractor = Extractor::new(&reader);
+        extractor
+            .overfetch(0.01)
+            .extract_bbox_to_writer(bbox, &mut output1)
+            .await
+            .unwrap()
+    };
+
+    // Extract with high overfetch
+    let stats_high = {
+        // Re-open the reader for second extraction
+        let backend2 = MmapBackend::try_from(crate::tests::VECTOR_FILE)
+            .await
+            .unwrap();
+        let reader2 = AsyncPmTilesReader::try_from_source(backend2).await.unwrap();
+
+        let mut output2 = Cursor::new(Vec::new());
+        let extractor2 = Extractor::new(&reader2);
+        extractor2
+            .overfetch(0.05)
+            .extract_bbox_to_writer(bbox, &mut output2)
+            .await
+            .unwrap()
+    };
+
+    // Higher overfetch may transfer more bytes...
+    assert!(
+        stats_high.num_tile_reqs() < stats_low.num_tile_reqs(),
+        "Higher overfetch should reduce requests: low={} high={}",
+        stats_low.num_tile_reqs(),
+        stats_high.num_tile_reqs()
+    );
+
+    // ...but it should reduce the number of requests
+    assert!(
+        stats_high.total_tile_transfer_bytes() > stats_low.total_tile_transfer_bytes(),
+        "Higher overfetch should increase requested bytes: low={} high={}",
+        stats_low.total_tile_transfer_bytes(),
+        stats_high.total_tile_transfer_bytes()
+    );
+
+    // The same number of tiles should be extracted
+    assert_eq!(
+        stats_low.addressed_tiles(),
+        stats_high.addressed_tiles(),
+        "Should extract same number of tiles"
+    );
+}

--- a/src/extract/tests/mod.rs
+++ b/src/extract/tests/mod.rs
@@ -1,0 +1,6 @@
+mod ranges_tests;
+mod reencode_tests;
+mod relevant_tests;
+
+#[cfg(feature = "__async")]
+mod integration_tests;

--- a/src/extract/tests/ranges_tests.rs
+++ b/src/extract/tests/ranges_tests.rs
@@ -1,0 +1,90 @@
+// Tests ported from go-pmtiles/pmtiles/extract_test.go
+// TestMergeRanges* functions (lines 138-175)
+
+use crate::extract::ranges::{SrcDstRange, merge_ranges};
+
+#[test]
+fn test_merge_ranges() {
+    // Port of: TestMergeRanges (lines 138-152)
+    let ranges = vec![
+        SrcDstRange {
+            src_offset: 0,
+            dst_offset: 0,
+            length: 50,
+        },
+        SrcDstRange {
+            src_offset: 60,
+            dst_offset: 60,
+            length: 60,
+        },
+    ];
+
+    let (result, total_transfer_bytes) = merge_ranges(&ranges, 0.1);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(total_transfer_bytes, 120);
+
+    let front = &result[0];
+    assert_eq!(front.range.src_offset, 0);
+    assert_eq!(front.range.dst_offset, 0);
+    assert_eq!(front.range.length, 120);
+    assert_eq!(front.copy_discards.len(), 2);
+    assert_eq!(front.copy_discards[0].wanted, 50);
+    assert_eq!(front.copy_discards[0].discard, 10);
+    assert_eq!(front.copy_discards[1].wanted, 60);
+    assert_eq!(front.copy_discards[1].discard, 0);
+}
+
+#[test]
+fn test_merge_ranges_multiple() {
+    // Port of: TestMergeRangesMultiple (lines 154-166)
+    let ranges = vec![
+        SrcDstRange {
+            src_offset: 0,
+            dst_offset: 0,
+            length: 50,
+        },
+        SrcDstRange {
+            src_offset: 60,
+            dst_offset: 60,
+            length: 10,
+        },
+        SrcDstRange {
+            src_offset: 80,
+            dst_offset: 80,
+            length: 10,
+        },
+    ];
+
+    let (result, total_transfer_bytes) = merge_ranges(&ranges, 0.3);
+
+    assert_eq!(total_transfer_bytes, 90);
+    assert_eq!(result.len(), 1);
+
+    let front = &result[0];
+    assert_eq!(front.range.src_offset, 0);
+    assert_eq!(front.range.dst_offset, 0);
+    assert_eq!(front.range.length, 90);
+    assert_eq!(front.copy_discards.len(), 3);
+}
+
+#[test]
+fn test_merge_ranges_non_src_ordered() {
+    // Port of: TestMergeRangesNonSrcOrdered (lines 168-175)
+    // Ranges not ordered by source offset should not merge
+    let ranges = vec![
+        SrcDstRange {
+            src_offset: 20,
+            dst_offset: 0,
+            length: 50,
+        },
+        SrcDstRange {
+            src_offset: 0,
+            dst_offset: 60,
+            length: 50,
+        },
+    ];
+
+    let (result, _) = merge_ranges(&ranges, 0.1);
+    assert_eq!(result.len(), 2);
+}

--- a/src/extract/tests/reencode_tests.rs
+++ b/src/extract/tests/reencode_tests.rs
@@ -1,0 +1,107 @@
+// Tests ported from go-pmtiles/pmtiles/extract_test.go
+// TestReencodeEntries* functions (lines 80-136)
+
+use crate::directory::DirEntry;
+use crate::extract::reencode_entries;
+
+#[test]
+fn test_reencode_entries() {
+    // Port of: TestReencodeEntries (lines 80-100)
+    let entries = vec![
+        DirEntry {
+            tile_id: 0,
+            offset: 400,
+            length: 10,
+            run_length: 1,
+        },
+        DirEntry {
+            tile_id: 1,
+            offset: 500,
+            length: 20,
+            run_length: 2,
+        },
+    ];
+
+    let (reencoded, result, datalen, addressed, contents) = reencode_entries(entries);
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].src_offset, 400);
+    assert_eq!(result[0].length, 10);
+    assert_eq!(result[1].src_offset, 500);
+    assert_eq!(result[1].length, 20);
+
+    assert_eq!(reencoded.len(), 2);
+    assert_eq!(reencoded[0].offset, 0);
+    assert_eq!(reencoded[1].offset, 10);
+
+    assert_eq!(datalen, 30);
+    assert_eq!(addressed, 3);
+    assert_eq!(contents, 2);
+}
+
+#[test]
+fn test_reencode_entries_duplicate() {
+    // Port of: TestReencodeEntriesDuplicate (lines 102-124)
+    let entries = vec![
+        DirEntry {
+            tile_id: 0,
+            offset: 400,
+            length: 10,
+            run_length: 1,
+        },
+        DirEntry {
+            tile_id: 1,
+            offset: 500,
+            length: 20,
+            run_length: 1,
+        },
+        DirEntry {
+            tile_id: 2,
+            offset: 400,
+            length: 10,
+            run_length: 1,
+        },
+    ];
+
+    let (reencoded, result, datalen, addressed, contents) = reencode_entries(entries);
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].src_offset, 400);
+    assert_eq!(result[0].length, 10);
+    assert_eq!(result[1].src_offset, 500);
+    assert_eq!(result[1].length, 20);
+
+    assert_eq!(reencoded.len(), 3);
+    assert_eq!(reencoded[0].offset, 0);
+    assert_eq!(reencoded[1].offset, 10);
+    assert_eq!(reencoded[2].offset, 0);
+
+    assert_eq!(datalen, 30);
+    assert_eq!(addressed, 3);
+    assert_eq!(contents, 2);
+}
+
+#[test]
+fn test_reencode_contiguous() {
+    // Port of: TestReencodeContiguous (lines 126-136)
+    let entries = vec![
+        DirEntry {
+            tile_id: 0,
+            offset: 400,
+            length: 10,
+            run_length: 0,
+        },
+        DirEntry {
+            tile_id: 1,
+            offset: 410,
+            length: 20,
+            run_length: 0,
+        },
+    ];
+
+    let (_, result, _, _, _) = reencode_entries(entries);
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].src_offset, 400);
+    assert_eq!(result[0].length, 30);
+}

--- a/src/extract/tests/relevant_tests.rs
+++ b/src/extract/tests/relevant_tests.rs
@@ -1,0 +1,121 @@
+// Tests ported from go-pmtiles/pmtiles/extract_test.go
+// TestRelevantEntries* functions (lines 9-78)
+
+use roaring::RoaringTreemap;
+
+use crate::directory::DirEntry;
+use crate::extract::relevant_entries;
+
+#[test]
+fn test_relevant_entries() {
+    // Port of: TestRelevantEntries (lines 9-20)
+    let entries = vec![DirEntry {
+        tile_id: 0,
+        offset: 0,
+        length: 0,
+        run_length: 1,
+    }];
+
+    let mut bitmap = RoaringTreemap::new();
+    bitmap.insert(0);
+
+    let (tiles, leaves) = relevant_entries(&bitmap, 4, &entries);
+
+    assert_eq!(tiles.len(), 1);
+    assert_eq!(leaves.len(), 0);
+}
+
+#[test]
+fn test_relevant_entries_run_length() {
+    // Port of: TestRelevantEntriesRunLength (lines 22-37)
+    let entries = vec![DirEntry {
+        tile_id: 0,
+        offset: 0,
+        length: 0,
+        run_length: 5,
+    }];
+
+    let mut bitmap = RoaringTreemap::new();
+    bitmap.insert(1);
+    bitmap.insert(2);
+    bitmap.insert(4);
+
+    let (tiles, leaves) = relevant_entries(&bitmap, 4, &entries);
+
+    assert_eq!(tiles.len(), 2);
+    assert_eq!(tiles[0].run_length, 2);
+    assert_eq!(tiles[1].run_length, 1);
+    assert_eq!(leaves.len(), 0);
+}
+
+#[test]
+fn test_relevant_entries_leaf() {
+    // Port of: TestRelevantEntriesLeaf (lines 39-50)
+    let entries = vec![DirEntry {
+        tile_id: 0,
+        offset: 0,
+        length: 0,
+        run_length: 0,
+    }];
+
+    let mut bitmap = RoaringTreemap::new();
+    bitmap.insert(1);
+
+    let (tiles, leaves) = relevant_entries(&bitmap, 4, &entries);
+
+    assert_eq!(tiles.len(), 0);
+    assert_eq!(leaves.len(), 1);
+}
+
+#[test]
+fn test_relevant_entries_not_leaf() {
+    // Port of: TestRelevantEntriesNotLeaf (lines 52-65)
+    let entries = vec![
+        DirEntry {
+            tile_id: 0,
+            offset: 0,
+            length: 0,
+            run_length: 0,
+        },
+        DirEntry {
+            tile_id: 2,
+            offset: 0,
+            length: 0,
+            run_length: 1,
+        },
+        DirEntry {
+            tile_id: 4,
+            offset: 0,
+            length: 0,
+            run_length: 0,
+        },
+    ];
+
+    let mut bitmap = RoaringTreemap::new();
+    bitmap.insert(3);
+
+    let (tiles, leaves) = relevant_entries(&bitmap, 4, &entries);
+
+    assert_eq!(tiles.len(), 0);
+    assert_eq!(leaves.len(), 0);
+}
+
+#[test]
+fn test_relevant_entries_max_zoom() {
+    // Port of: TestRelevantEntriesMaxZoom (lines 67-78)
+    let entries = vec![DirEntry {
+        tile_id: 0,
+        offset: 0,
+        length: 0,
+        run_length: 0,
+    }];
+
+    let mut bitmap = RoaringTreemap::new();
+    bitmap.insert(6);
+
+    let (_, leaves) = relevant_entries(&bitmap, 1, &entries);
+    assert_eq!(leaves.len(), 0);
+
+    let (_, leaves) = relevant_entries(&bitmap, 2, &entries);
+    assert_eq!(leaves.len(), 1);
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -10,7 +10,7 @@ pub(crate) const MAX_INITIAL_BYTES: usize = 16_384;
 #[cfg(any(test, feature = "__async", feature = "write"))]
 pub(crate) const HEADER_SIZE: usize = 127;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 /// The header of a `PMTiles` file, containing metadata about the tiles.
 pub struct Header {
@@ -348,7 +348,7 @@ impl crate::writer::WriteTo for Header {
 
 impl Header {
     #[cfg(feature = "write")]
-    #[expect(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_truncation)]
     fn write_coordinate_part<W: std::io::Write>(writer: &mut W, value: f64) -> std::io::Result<()> {
         writer.write_all(&((value * 10_000_000.0).round() as i32).to_le_bytes())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub use cache::{DirCacheResult, DirectoryCache, HashMapCache, NoCache};
 
 mod directory;
 mod error;
+#[cfg(feature = "extract")]
+pub mod extract;
 mod header;
 mod tile;
 #[cfg(feature = "write")]


### PR DESCRIPTION
In a rust project I'm working on, I want to slice out a subset of a pmtiles archive (just like the go `pmtiles extract` command).

You can see it in action in this video, where I extract an area around the city of Seattle from a planet.pmtiles using the HTTP (range request) backend.

https://github.com/user-attachments/assets/5d7121f2-ee11-4219-8fc7-d6f990b59df0

In the log, the first 8 requests traverse the necessary metadata and directories to figure out where all the tiles live. The next 36 requests fetch the tile data.

It was a large endeavor, and to be honest, when I started, I wasn't sure it was going to work out, but it went relatively well! Unfortunately, this branch is kind of a mess. I'm going to carve out some bite-sized PR's from this branch, more suitable for human consumption, but I wanted to have this as a reference in case anyone wanted the bigger picture.