### PR TITLE
Configurable compression parameters via Compressor trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,8 @@ pub use tile::{MAX_TILE_ID, MAX_ZOOM, PYRAMID_SIZE_BY_ZOOM, TileCoord, TileId};
 /// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "tilejson")]
 pub use tilejson;
-#[cfg(all(feature = "write", feature = "brotli"))]
-pub use writer::BrotliCompressor;
-#[cfg(all(feature = "write", feature = "zstd"))]
-pub use writer::ZstdCompressor;
 #[cfg(feature = "write")]
-pub use writer::{Compressor, GzipCompressor, NoCompression, PmTilesStreamWriter, PmTilesWriter};
+pub use writer::{Compressor, PmTilesStreamWriter, PmTilesWriter};
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,12 @@ pub use tile::{MAX_TILE_ID, MAX_ZOOM, PYRAMID_SIZE_BY_ZOOM, TileCoord, TileId};
 /// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "tilejson")]
 pub use tilejson;
+#[cfg(all(feature = "write", feature = "brotli"))]
+pub use writer::BrotliCompressor;
+#[cfg(all(feature = "write", feature = "zstd"))]
+pub use writer::ZstdCompressor;
 #[cfg(feature = "write")]
-pub use writer::{PmTilesStreamWriter, PmTilesWriter};
+pub use writer::{Compressor, GzipCompressor, NoCompression, PmTilesStreamWriter, PmTilesWriter};
 
 #[cfg(test)]
 mod tests {

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -80,8 +80,6 @@ impl Compressor for BrotliCompressor {
     ) -> PmtResult<()> {
         let mut encoder = brotli::CompressorWriter::with_params(output, 4096, &self.0);
         input(&mut encoder)?;
-        // CompressorWriter flushes on drop
-        drop(encoder);
         Ok(())
     }
 }

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -10,16 +10,16 @@ pub trait Compressor {
     /// Returns the compression type for the `PMTiles` header.
     fn compression(&self) -> Compression;
 
-    /// Create an encoder wrapping `output`, invoke `input` to write
-    /// uncompressed data into it, then finalize the encoder.
+    /// Invoke `input` to write uncompressed data into an encoder
+    /// wrapping `output`, then finalize the encoder.
     ///
     /// # Errors
     ///
     /// Returns an error if writing to `output` fails or the compression fails.
     fn compress(
         &self,
-        output: &mut dyn Write,
         input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        output: &mut dyn Write,
     ) -> PmtResult<()>;
 }
 
@@ -30,10 +30,10 @@ impl<T: Compressor + ?Sized> Compressor for Box<T> {
 
     fn compress(
         &self,
-        output: &mut dyn Write,
         input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        output: &mut dyn Write,
     ) -> PmtResult<()> {
-        (**self).compress(output, input)
+        (**self).compress(input, output)
     }
 }
 
@@ -47,8 +47,8 @@ impl Compressor for NoCompression {
 
     fn compress(
         &self,
-        output: &mut dyn Write,
         input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        output: &mut dyn Write,
     ) -> PmtResult<()> {
         input(output)?;
         Ok(())
@@ -66,8 +66,8 @@ impl Compressor for GzipCompressor {
 
     fn compress(
         &self,
-        output: &mut dyn Write,
         input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        output: &mut dyn Write,
     ) -> PmtResult<()> {
         let mut encoder = GzEncoder::new(output, self.0);
         input(&mut encoder)?;
@@ -89,8 +89,8 @@ impl Compressor for BrotliCompressor {
 
     fn compress(
         &self,
-        output: &mut dyn Write,
         input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        output: &mut dyn Write,
     ) -> PmtResult<()> {
         let mut encoder = brotli::CompressorWriter::with_params(output, 4096, &self.0);
         input(&mut encoder)?;
@@ -110,8 +110,8 @@ impl Compressor for ZstdCompressor {
 
     fn compress(
         &self,
-        output: &mut dyn Write,
         input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        output: &mut dyn Write,
     ) -> PmtResult<()> {
         let mut encoder = zstd::stream::Encoder::new(output, self.0)?;
         input(&mut encoder)?;
@@ -152,8 +152,8 @@ impl Compressor for UnsupportedCompressor {
 
     fn compress(
         &self,
-        _output: &mut dyn Write,
         _input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        _output: &mut dyn Write,
     ) -> PmtResult<()> {
         Err(PmtError::UnsupportedCompression(self.0))
     }

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -10,16 +10,16 @@ pub trait Compressor {
     /// Returns the compression type for the `PMTiles` header.
     fn compression(&self) -> Compression;
 
-    /// Invoke `input` to write uncompressed data into an encoder
-    /// wrapping `output`, then finalize the encoder.
+    /// Invoke `f` to write uncompressed data into an encoder
+    /// wrapping `writer`, then finalize the encoder.
     ///
     /// # Errors
     ///
     /// Returns an error if writing to `output` fails or the compression fails.
     fn compress(
         &self,
-        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        output: &mut dyn Write,
+        f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        writer: &mut dyn Write,
     ) -> PmtResult<()>;
 }
 
@@ -30,10 +30,10 @@ impl<T: Compressor + ?Sized> Compressor for Box<T> {
 
     fn compress(
         &self,
-        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        output: &mut dyn Write,
+        f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        writer: &mut dyn Write,
     ) -> PmtResult<()> {
-        (**self).compress(input, output)
+        (**self).compress(f, writer)
     }
 }
 
@@ -47,10 +47,10 @@ impl Compressor for NoCompression {
 
     fn compress(
         &self,
-        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        output: &mut dyn Write,
+        f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        writer: &mut dyn Write,
     ) -> PmtResult<()> {
-        input(output)?;
+        f(writer)?;
         Ok(())
     }
 }
@@ -66,11 +66,11 @@ impl Compressor for GzipCompressor {
 
     fn compress(
         &self,
-        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        output: &mut dyn Write,
+        f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        writer: &mut dyn Write,
     ) -> PmtResult<()> {
-        let mut encoder = GzEncoder::new(output, self.0);
-        input(&mut encoder)?;
+        let mut encoder = GzEncoder::new(writer, self.0);
+        f(&mut encoder)?;
         encoder.finish()?;
         Ok(())
     }
@@ -89,11 +89,11 @@ impl Compressor for BrotliCompressor {
 
     fn compress(
         &self,
-        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        output: &mut dyn Write,
+        f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        writer: &mut dyn Write,
     ) -> PmtResult<()> {
-        let mut encoder = brotli::CompressorWriter::with_params(output, 4096, &self.0);
-        input(&mut encoder)?;
+        let mut encoder = brotli::CompressorWriter::with_params(writer, 4096, &self.0);
+        f(&mut encoder)?;
         Ok(())
     }
 }
@@ -110,11 +110,11 @@ impl Compressor for ZstdCompressor {
 
     fn compress(
         &self,
-        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        output: &mut dyn Write,
+        f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        writer: &mut dyn Write,
     ) -> PmtResult<()> {
-        let mut encoder = zstd::stream::Encoder::new(output, self.0)?;
-        input(&mut encoder)?;
+        let mut encoder = zstd::stream::Encoder::new(writer, self.0)?;
+        f(&mut encoder)?;
         encoder.finish()?;
         Ok(())
     }
@@ -152,8 +152,8 @@ impl Compressor for UnsupportedCompressor {
 
     fn compress(
         &self,
-        _input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
-        _output: &mut dyn Write,
+        _f: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+        _writer: &mut dyn Write,
     ) -> PmtResult<()> {
         Err(PmtError::UnsupportedCompression(self.0))
     }

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -23,6 +23,20 @@ pub trait Compressor {
     ) -> PmtResult<()>;
 }
 
+impl<T: Compressor + ?Sized> Compressor for Box<T> {
+    fn compression(&self) -> Compression {
+        (**self).compression()
+    }
+
+    fn compress(
+        &self,
+        output: &mut dyn Write,
+        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()> {
+        (**self).compress(output, input)
+    }
+}
+
 /// Passthrough (no compression).
 pub(crate) struct NoCompression;
 

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -63,8 +63,7 @@ impl Compressor for BrotliCompressor {
     fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
         let mut encoder = brotli::CompressorWriter::with_params(output, 4096, &self.0);
         encoder.write_all(input)?;
-        // CompressorWriter flushes on drop; explicit drop to catch errors via Write trait
-        drop(encoder);
+        encoder.flush()?;
         Ok(())
     }
 }

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -24,7 +24,7 @@ pub trait Compressor {
 }
 
 /// Passthrough (no compression).
-pub struct NoCompression;
+pub(crate) struct NoCompression;
 
 impl Compressor for NoCompression {
     fn compression(&self) -> Compression {
@@ -43,7 +43,7 @@ impl Compressor for NoCompression {
 
 /// Gzip compression. Wraps [`flate2::Compression`] for level configuration.
 #[derive(Default)]
-pub struct GzipCompressor(pub flate2::Compression);
+pub(crate) struct GzipCompressor(pub(crate) flate2::Compression);
 
 impl Compressor for GzipCompressor {
     fn compression(&self) -> Compression {
@@ -65,7 +65,7 @@ impl Compressor for GzipCompressor {
 /// Brotli compression. Wraps [`brotli::enc::BrotliEncoderParams`].
 #[cfg(feature = "brotli")]
 #[derive(Default)]
-pub struct BrotliCompressor(pub brotli::enc::BrotliEncoderParams);
+pub(crate) struct BrotliCompressor(pub(crate) brotli::enc::BrotliEncoderParams);
 
 #[cfg(feature = "brotli")]
 impl Compressor for BrotliCompressor {
@@ -88,7 +88,7 @@ impl Compressor for BrotliCompressor {
 
 /// Zstd compression with configurable level.
 #[cfg(feature = "zstd")]
-pub struct ZstdCompressor(pub i32);
+pub(crate) struct ZstdCompressor(pub(crate) i32);
 
 #[cfg(feature = "zstd")]
 impl Compressor for ZstdCompressor {

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -1,0 +1,123 @@
+use std::io::Write;
+
+use flate2::write::GzEncoder;
+
+use crate::{Compression, PmtError, PmtResult};
+
+/// Trait for compression implementations.
+/// Implement this to provide custom compression behavior.
+pub trait Compressor {
+    /// Returns the compression type for the `PMTiles` header.
+    fn compression(&self) -> Compression;
+
+    /// Compress `input` and write the compressed data to `output`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing to `output` fails or the compression fails.
+    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()>;
+}
+
+/// Passthrough (no compression).
+pub struct NoCompression;
+
+impl Compressor for NoCompression {
+    fn compression(&self) -> Compression {
+        Compression::None
+    }
+
+    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+        output.write_all(input)?;
+        Ok(())
+    }
+}
+
+/// Gzip compression. Wraps [`flate2::Compression`] for level configuration.
+#[derive(Default)]
+pub struct GzipCompressor(pub flate2::Compression);
+
+impl Compressor for GzipCompressor {
+    fn compression(&self) -> Compression {
+        Compression::Gzip
+    }
+
+    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+        let mut encoder = GzEncoder::new(output, self.0);
+        encoder.write_all(input)?;
+        encoder.finish()?;
+        Ok(())
+    }
+}
+
+/// Brotli compression. Wraps [`brotli::enc::BrotliEncoderParams`].
+#[cfg(feature = "brotli")]
+#[derive(Default)]
+pub struct BrotliCompressor(pub brotli::enc::BrotliEncoderParams);
+
+#[cfg(feature = "brotli")]
+impl Compressor for BrotliCompressor {
+    fn compression(&self) -> Compression {
+        Compression::Brotli
+    }
+
+    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+        let mut encoder = brotli::CompressorWriter::with_params(output, 4096, &self.0);
+        encoder.write_all(input)?;
+        // CompressorWriter flushes on drop; explicit drop to catch errors via Write trait
+        drop(encoder);
+        Ok(())
+    }
+}
+
+/// Zstd compression with configurable level.
+#[cfg(feature = "zstd")]
+pub struct ZstdCompressor(pub i32);
+
+#[cfg(feature = "zstd")]
+impl Compressor for ZstdCompressor {
+    fn compression(&self) -> Compression {
+        Compression::Zstd
+    }
+
+    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+        let mut encoder = zstd::stream::Encoder::new(output, self.0)?;
+        encoder.write_all(input)?;
+        encoder.finish()?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "zstd")]
+impl Default for ZstdCompressor {
+    fn default() -> Self {
+        Self(zstd::DEFAULT_COMPRESSION_LEVEL)
+    }
+}
+
+impl From<Compression> for Box<dyn Compressor> {
+    fn from(compression: Compression) -> Self {
+        match compression {
+            Compression::None => Box::new(NoCompression),
+            Compression::Gzip => Box::new(GzipCompressor::default()),
+            #[cfg(feature = "brotli")]
+            Compression::Brotli => Box::new(BrotliCompressor::default()),
+            #[cfg(feature = "zstd")]
+            Compression::Zstd => Box::new(ZstdCompressor::default()),
+            v => Box::new(UnsupportedCompressor(v)),
+        }
+    }
+}
+
+/// Stub compressor for codecs whose feature is disabled.
+/// Returns an error when compression is attempted.
+struct UnsupportedCompressor(Compression);
+
+impl Compressor for UnsupportedCompressor {
+    fn compression(&self) -> Compression {
+        self.0
+    }
+
+    fn compress(&self, _input: &[u8], _output: &mut dyn Write) -> PmtResult<()> {
+        Err(PmtError::UnsupportedCompression(self.0))
+    }
+}

--- a/src/writer/compressor.rs
+++ b/src/writer/compressor.rs
@@ -10,12 +10,17 @@ pub trait Compressor {
     /// Returns the compression type for the `PMTiles` header.
     fn compression(&self) -> Compression;
 
-    /// Compress `input` and write the compressed data to `output`.
+    /// Create an encoder wrapping `output`, invoke `input` to write
+    /// uncompressed data into it, then finalize the encoder.
     ///
     /// # Errors
     ///
     /// Returns an error if writing to `output` fails or the compression fails.
-    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()>;
+    fn compress(
+        &self,
+        output: &mut dyn Write,
+        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()>;
 }
 
 /// Passthrough (no compression).
@@ -26,8 +31,12 @@ impl Compressor for NoCompression {
         Compression::None
     }
 
-    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
-        output.write_all(input)?;
+    fn compress(
+        &self,
+        output: &mut dyn Write,
+        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()> {
+        input(output)?;
         Ok(())
     }
 }
@@ -41,9 +50,13 @@ impl Compressor for GzipCompressor {
         Compression::Gzip
     }
 
-    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+    fn compress(
+        &self,
+        output: &mut dyn Write,
+        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()> {
         let mut encoder = GzEncoder::new(output, self.0);
-        encoder.write_all(input)?;
+        input(&mut encoder)?;
         encoder.finish()?;
         Ok(())
     }
@@ -60,10 +73,15 @@ impl Compressor for BrotliCompressor {
         Compression::Brotli
     }
 
-    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+    fn compress(
+        &self,
+        output: &mut dyn Write,
+        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()> {
         let mut encoder = brotli::CompressorWriter::with_params(output, 4096, &self.0);
-        encoder.write_all(input)?;
-        encoder.flush()?;
+        input(&mut encoder)?;
+        // CompressorWriter flushes on drop
+        drop(encoder);
         Ok(())
     }
 }
@@ -78,9 +96,13 @@ impl Compressor for ZstdCompressor {
         Compression::Zstd
     }
 
-    fn compress(&self, input: &[u8], output: &mut dyn Write) -> PmtResult<()> {
+    fn compress(
+        &self,
+        output: &mut dyn Write,
+        input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()> {
         let mut encoder = zstd::stream::Encoder::new(output, self.0)?;
-        encoder.write_all(input)?;
+        input(&mut encoder)?;
         encoder.finish()?;
         Ok(())
     }
@@ -116,7 +138,11 @@ impl Compressor for UnsupportedCompressor {
         self.0
     }
 
-    fn compress(&self, _input: &[u8], _output: &mut dyn Write) -> PmtResult<()> {
+    fn compress(
+        &self,
+        _output: &mut dyn Write,
+        _input: &mut dyn FnMut(&mut dyn Write) -> std::io::Result<()>,
+    ) -> PmtResult<()> {
         Err(PmtError::UnsupportedCompression(self.0))
     }
 }

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -881,10 +881,10 @@ mod tests {
 
             fn compress(
                 &self,
-                input: &mut dyn FnMut(&mut dyn std::io::Write) -> std::io::Result<()>,
-                output: &mut dyn std::io::Write,
+                f: &mut dyn FnMut(&mut dyn std::io::Write) -> std::io::Result<()>,
+                writer: &mut dyn std::io::Write,
             ) -> crate::PmtResult<()> {
-                NoCompression.compress(input, output)
+                NoCompression.compress(f, writer)
             }
         }
 

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -800,25 +800,9 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[tokio::test]
     async fn zstd_compressor_roundtrip() {
-        use crate::{Compressor, ZstdCompressor};
+        use crate::ZstdCompressor;
 
         let test_data = b"hello pmtiles zstd compressor with custom level";
-
-        // Verify custom level produces different output than default
-        let custom = ZstdCompressor(19);
-        let default = ZstdCompressor::default();
-        let mut custom_buf = Vec::new();
-        let mut default_buf = Vec::new();
-        custom.compress(test_data, &mut custom_buf).unwrap();
-        default.compress(test_data, &mut default_buf).unwrap();
-        assert_ne!(
-            custom_buf, default_buf,
-            "custom level should differ from default"
-        );
-        assert!(
-            custom_buf.len() < default_buf.len(),
-            "level 19 should compress better than default"
-        );
 
         let path = get_temp_file_path("pmtiles").unwrap();
         let file = File::create(&path).unwrap();
@@ -845,25 +829,7 @@ mod tests {
 
     #[tokio::test]
     async fn gzip_compressor_best_roundtrip() {
-        use crate::Compressor;
-
         let test_data = b"hello pmtiles gzip best compressor with enough data to see a difference";
-
-        // Verify best compression produces different output than default
-        let custom = GzipCompressor(flate2::Compression::best());
-        let default = GzipCompressor::default();
-        let mut custom_buf = Vec::new();
-        let mut default_buf = Vec::new();
-        custom.compress(test_data, &mut custom_buf).unwrap();
-        default.compress(test_data, &mut default_buf).unwrap();
-        assert_ne!(
-            custom_buf, default_buf,
-            "best level should differ from default"
-        );
-        assert!(
-            custom_buf.len() <= default_buf.len(),
-            "best should compress at least as well as default"
-        );
 
         let path = get_temp_file_path("pmtiles").unwrap();
         let file = File::create(&path).unwrap();
@@ -893,7 +859,7 @@ mod tests {
         use crate::writer::compressor::{Compressor, NoCompression};
 
         /// A custom compressor that just delegates to `NoCompression`
-        /// but reports itself as Gzip (for testing the trait mechanism).
+        /// (for testing the trait mechanism).
         struct CustomTestCompressor;
 
         impl Compressor for CustomTestCompressor {
@@ -933,33 +899,17 @@ mod tests {
     #[cfg(feature = "brotli")]
     #[tokio::test]
     async fn brotli_compressor_roundtrip() {
-        use crate::{BrotliCompressor, Compressor};
+        use crate::BrotliCompressor;
 
         let test_data = b"hello pmtiles brotli compressor with enough data to see a difference";
-
-        // Verify custom quality produces different output than default
-        let custom = BrotliCompressor(brotli::enc::BrotliEncoderParams {
-            quality: 5,
-            ..Default::default()
-        });
-        let default = BrotliCompressor::default();
-        let mut custom_buf = Vec::new();
-        let mut default_buf = Vec::new();
-        custom.compress(test_data, &mut custom_buf).unwrap();
-        default.compress(test_data, &mut default_buf).unwrap();
-        assert_ne!(
-            custom_buf, default_buf,
-            "custom quality should differ from default"
-        );
-        assert!(
-            custom_buf.len() > default_buf.len(),
-            "quality 5 should compress worse than default (quality 11)"
-        );
 
         let path = get_temp_file_path("pmtiles").unwrap();
         let file = File::create(&path).unwrap();
         let mut writer = PmTilesWriter::new(TileType::Mvt)
-            .tile_codec(custom)
+            .tile_codec(BrotliCompressor(brotli::enc::BrotliEncoderParams {
+                quality: 5,
+                ..Default::default()
+            }))
             .create(file)
             .unwrap();
 

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -233,7 +233,7 @@ impl PmTilesWriter {
         let metadata_length = self
             .metadata
             .as_bytes()
-            .write_compressed_to_counted(&mut out, &*self.internal_compressor)?
+            .write_compressed_to_counted(&mut out, &self.internal_compressor)?
             as u64;
 
         let mut state = WriterState {
@@ -270,7 +270,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     /// If writing to the output stream fails
     pub fn add_tile(&mut self, coord: TileCoord, data: &[u8]) -> PmtResult<()> {
         self.state
-            .add_tile_by_id(coord.into(), data, &*self.tile_compressor)
+            .add_tile_by_id(coord.into(), data, &self.tile_compressor)
     }
 
     /// Add a pre-compressed tile to the writer.
@@ -461,7 +461,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
             - state.header.metadata_length;
 
         // Write leaf directories and get a root directory
-        let root_dir = state.build_directories(&*self.internal_compressor)?;
+        let root_dir = state.build_directories(&self.internal_compressor)?;
 
         state.header.n_addressed_tiles = state.n_addressed_tiles.try_into().ok();
         state.header.n_tile_contents = (state.tile_content_map.len() as u64).try_into().ok();
@@ -469,7 +469,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
 
         // Determine compressed root directory length
         let mut root_dir_buf = vec![];
-        root_dir.write_compressed_to(&mut root_dir_buf, &*self.internal_compressor)?;
+        root_dir.write_compressed_to(&mut root_dir_buf, &self.internal_compressor)?;
         state.header.root_length = root_dir_buf.len() as u64;
 
         // Write header and root directory

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -81,9 +81,10 @@ pub(crate) trait WriteTo {
         writer: &mut W,
         compressor: &dyn Compressor,
     ) -> PmtResult<()> {
-        compressor.compress(writer, &mut |encoder| {
-            self.write_to(&mut DynWriter(encoder))
-        })
+        compressor.compress(
+            &mut |encoder| self.write_to(&mut DynWriter(encoder)),
+            writer,
+        )
     }
 
     fn write_compressed_to_counted<W: Write>(
@@ -880,10 +881,10 @@ mod tests {
 
             fn compress(
                 &self,
-                output: &mut dyn std::io::Write,
                 input: &mut dyn FnMut(&mut dyn std::io::Write) -> std::io::Result<()>,
+                output: &mut dyn std::io::Write,
             ) -> crate::PmtResult<()> {
-                NoCompression.compress(output, input)
+                NoCompression.compress(input, output)
             }
         }
 

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -8,11 +8,8 @@ use std::io::{BufWriter, Seek, Write};
 use countio::Counter;
 use twox_hash::XxHash3_64;
 
-#[cfg(feature = "brotli")]
-pub use compressor::BrotliCompressor;
-#[cfg(feature = "zstd")]
-pub use compressor::ZstdCompressor;
-pub use compressor::{Compressor, GzipCompressor, NoCompression};
+pub use compressor::Compressor;
+pub(crate) use compressor::{GzipCompressor, NoCompression};
 
 use crate::header::{HEADER_SIZE, MAX_INITIAL_BYTES};
 use crate::{
@@ -503,9 +500,10 @@ mod tests {
 
     use crate::tests::RASTER_FILE;
     use crate::{
-        AsyncPmTilesReader, Compression, GzipCompressor, MmapBackend, PmTilesWriter, TileCoord,
-        TileId, TileType,
+        AsyncPmTilesReader, Compression, MmapBackend, PmTilesWriter, TileCoord, TileId, TileType,
     };
+
+    use super::GzipCompressor;
 
     fn get_temp_file_path(suffix: &str) -> std::io::Result<String> {
         let temp_file = NamedTempFile::with_suffix(suffix)?;
@@ -812,7 +810,7 @@ mod tests {
     #[cfg(feature = "zstd")]
     #[tokio::test]
     async fn zstd_compressor_roundtrip() {
-        use crate::ZstdCompressor;
+        use super::compressor::ZstdCompressor;
 
         let test_data = b"hello pmtiles zstd compressor with custom level";
 
@@ -868,7 +866,7 @@ mod tests {
 
     #[tokio::test]
     async fn custom_compressor_roundtrip() {
-        use crate::writer::compressor::{Compressor, NoCompression};
+        use super::{Compressor, NoCompression};
 
         /// A custom compressor that just delegates to `NoCompression`
         /// (for testing the trait mechanism).
@@ -911,7 +909,7 @@ mod tests {
     #[cfg(feature = "brotli")]
     #[tokio::test]
     async fn brotli_compressor_roundtrip() {
-        use crate::BrotliCompressor;
+        use super::compressor::BrotliCompressor;
 
         let test_data = b"hello pmtiles brotli compressor with enough data to see a difference";
 

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -113,12 +113,12 @@ impl PmTilesWriter {
     /// Create a new `PMTiles` writer with default values.
     #[must_use]
     pub fn new(tile_type: TileType) -> Self {
-        let (tile_compression, tile_compressor): (_, Box<dyn Compressor>) = match tile_type {
-            TileType::Mvt => (Compression::Gzip, Box::new(GzipCompressor::default())),
-            _ => (Compression::None, Box::new(NoCompression)),
+        let tile_compressor: Box<dyn Compressor> = match tile_type {
+            TileType::Mvt => Box::new(GzipCompressor::default()),
+            _ => Box::new(NoCompression),
         };
-        let header = Header::new(tile_compression, tile_type);
         let internal_compressor: Box<dyn Compressor> = Box::new(GzipCompressor::default());
+        let header = Header::new(tile_compressor.compression(), tile_type);
         Self {
             header,
             metadata: "{}".to_string(),

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -1,13 +1,19 @@
+mod compressor;
+
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::hash::BuildHasherDefault;
 use std::io::{BufWriter, Seek, Write};
 
 use countio::Counter;
-use flate2::write::GzEncoder;
 use twox_hash::XxHash3_64;
 
-use crate::PmtError::UnsupportedCompression;
+#[cfg(feature = "brotli")]
+pub use compressor::BrotliCompressor;
+#[cfg(feature = "zstd")]
+pub use compressor::ZstdCompressor;
+pub use compressor::{Compressor, GzipCompressor, NoCompression};
+
 use crate::header::{HEADER_SIZE, MAX_INITIAL_BYTES};
 use crate::{
     Compression, DirEntry, Directory, Header, PmtError, PmtResult, TileCoord, TileId, TileType,
@@ -20,6 +26,8 @@ const MAX_ROOT_DIR_BYTES: usize = MAX_INITIAL_BYTES - HEADER_SIZE;
 pub struct PmTilesWriter {
     header: Header,
     metadata: String,
+    tile_compressor: Box<dyn Compressor>,
+    internal_compressor: Box<dyn Compressor>,
 }
 
 struct TileContentLocation {
@@ -29,6 +37,14 @@ struct TileContentLocation {
 
 /// `PMTiles` streaming writer.
 pub struct PmTilesStreamWriter<W: Write + Seek> {
+    state: WriterState<W>,
+    tile_compressor: Box<dyn Compressor>,
+    internal_compressor: Box<dyn Compressor>,
+}
+
+/// Separated from `PmTilesStreamWriter` so that internal methods can borrow
+/// this state mutably while `finalize` simultaneously reads the compressors.
+struct WriterState<W: Write + Seek> {
     out: Counter<BufWriter<W>>,
     header: Header,
     entries: Vec<DirEntry>,
@@ -53,46 +69,27 @@ pub(crate) trait WriteTo {
     fn write_compressed_to<W: Write>(
         &self,
         writer: &mut W,
-        compression: Compression,
+        compressor: &dyn Compressor,
     ) -> PmtResult<()> {
-        match compression {
-            Compression::None => self.write_to(writer)?,
-            Compression::Gzip => {
-                let mut encoder = GzEncoder::new(writer, flate2::Compression::default());
-                self.write_to(&mut encoder)?;
-                encoder.finish()?;
-            }
-            #[cfg(feature = "brotli")]
-            Compression::Brotli => {
-                let params = brotli::enc::BrotliEncoderParams::default();
-                let mut encoder = brotli::CompressorWriter::with_params(writer, 4096, &params);
-                self.write_to(&mut encoder)?;
-            }
-            #[cfg(feature = "zstd")]
-            Compression::Zstd => {
-                let mut encoder =
-                    zstd::stream::Encoder::new(writer, zstd::DEFAULT_COMPRESSION_LEVEL)?;
-                self.write_to(&mut encoder)?;
-                encoder.finish()?;
-            }
-            v => Err(UnsupportedCompression(v))?,
-        }
+        let mut buf = Vec::new();
+        self.write_to(&mut buf)?;
+        compressor.compress(&buf, writer)?;
         Ok(())
     }
 
     fn write_compressed_to_counted<W: Write>(
         &self,
         writer: &mut Counter<W>,
-        compression: Compression,
+        compressor: &dyn Compressor,
     ) -> PmtResult<usize> {
         let pos = writer.writer_bytes();
-        self.write_compressed_to(writer, compression)?;
+        self.write_compressed_to(writer, compressor)?;
         Ok(writer.writer_bytes() - pos)
     }
 
-    fn compressed_size(&self, compression: Compression) -> PmtResult<usize> {
+    fn compressed_size(&self, compressor: &dyn Compressor) -> PmtResult<usize> {
         let mut devnull = Counter::new(std::io::sink());
-        self.write_compressed_to(&mut devnull, compression)?;
+        self.write_compressed_to(&mut devnull, compressor)?;
         Ok(devnull.writer_bytes())
     }
 }
@@ -107,28 +104,53 @@ impl PmTilesWriter {
     /// Create a new `PMTiles` writer with default values.
     #[must_use]
     pub fn new(tile_type: TileType) -> Self {
-        let tile_compression = match tile_type {
-            TileType::Mvt => Compression::Gzip,
-            _ => Compression::None,
+        let (tile_compression, tile_compressor): (_, Box<dyn Compressor>) = match tile_type {
+            TileType::Mvt => (Compression::Gzip, Box::new(GzipCompressor::default())),
+            _ => (Compression::None, Box::new(NoCompression)),
         };
         let header = Header::new(tile_compression, tile_type);
+        let internal_compressor: Box<dyn Compressor> = Box::new(GzipCompressor::default());
         Self {
             header,
             metadata: "{}".to_string(),
+            tile_compressor,
+            internal_compressor,
         }
     }
 
-    /// Set the compression for metadata and directories.
+    /// Set the compression for metadata and directories using a default compressor.
+    ///
+    /// For custom compression parameters, use [`internal_codec`](Self::internal_codec) instead.
     #[must_use]
     pub fn internal_compression(mut self, compression: Compression) -> Self {
         self.header.internal_compression = compression;
+        self.internal_compressor = compression.into();
         self
     }
 
-    /// Set the compression for tile data.
+    /// Set the compression for tile data using a default compressor.
+    ///
+    /// For custom compression parameters, use [`tile_codec`](Self::tile_codec) instead.
     #[must_use]
     pub fn tile_compression(mut self, compression: Compression) -> Self {
         self.header.tile_compression = compression;
+        self.tile_compressor = compression.into();
+        self
+    }
+
+    /// Set the tile compressor. Also sets the header's tile compression.
+    #[must_use]
+    pub fn tile_codec(mut self, compressor: impl Compressor + 'static) -> Self {
+        self.header.tile_compression = compressor.compression();
+        self.tile_compressor = Box::new(compressor);
+        self
+    }
+
+    /// Set the internal (metadata/directory) compressor.
+    #[must_use]
+    pub fn internal_codec(mut self, compressor: impl Compressor + 'static) -> Self {
+        self.header.internal_compression = compressor.compression();
+        self.internal_compressor = Box::new(compressor);
         self
     }
 
@@ -202,10 +224,10 @@ impl PmTilesWriter {
         let metadata_length = self
             .metadata
             .as_bytes()
-            .write_compressed_to_counted(&mut out, self.header.internal_compression)?
+            .write_compressed_to_counted(&mut out, &*self.internal_compressor)?
             as u64;
 
-        let mut writer = PmTilesStreamWriter {
+        let mut state = WriterState {
             out,
             header: self.header,
             entries: Vec::new(),
@@ -215,8 +237,14 @@ impl PmTilesWriter {
             prev_tile_hash: None,
             prev_written_tile_offset: 0,
         };
-        writer.header.metadata_length = metadata_length;
-        writer.header.data_offset = MAX_INITIAL_BYTES as u64 + metadata_length;
+        state.header.metadata_length = metadata_length;
+        state.header.data_offset = MAX_INITIAL_BYTES as u64 + metadata_length;
+
+        let writer = PmTilesStreamWriter {
+            state,
+            tile_compressor: self.tile_compressor,
+            internal_compressor: self.internal_compressor,
+        };
 
         Ok(writer)
     }
@@ -232,7 +260,8 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     ///
     /// If writing to the output stream fails
     pub fn add_tile(&mut self, coord: TileCoord, data: &[u8]) -> PmtResult<()> {
-        self.add_tile_by_id(coord.into(), data, self.header.tile_compression)
+        self.state
+            .add_tile_by_id(coord.into(), data, &*self.tile_compressor)
     }
 
     /// Add a pre-compressed tile to the writer.
@@ -247,22 +276,21 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     ///
     /// If writing to the output stream fails
     pub fn add_raw_tile(&mut self, coord: TileCoord, data: &[u8]) -> PmtResult<()> {
-        self.add_tile_by_id(coord.into(), data, Compression::None)
+        self.state
+            .add_tile_by_id(coord.into(), data, &NoCompression)
     }
+}
 
+impl<W: Write + Seek> WriterState<W> {
     /// Add a tile to the writer.
     ///
     /// Tiles are deduplicated and written to output.
     /// The `tile_id` should be increasing for best read performance.
-    ///
-    /// # Errors
-    ///
-    /// If writing to the output stream fails
     fn add_tile_by_id(
         &mut self,
         tile_id: TileId,
         data: &[u8],
-        tile_compression: Compression,
+        compressor: &dyn Compressor,
     ) -> PmtResult<()> {
         if data.is_empty() {
             // Ignore empty tiles, since the spec does not allow storing them
@@ -295,7 +323,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
             Entry::Occupied(e) => e.into_mut(),
             Entry::Vacant(e) => {
                 let offset = self.prev_written_tile_offset;
-                let len = data.write_compressed_to_counted(&mut self.out, tile_compression)?;
+                let len = data.write_compressed_to_counted(&mut self.out, compressor)?;
                 self.prev_written_tile_offset += len as u64;
                 let length = into_u32(len)?;
                 e.insert(TileContentLocation { offset, length })
@@ -320,13 +348,13 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     /// The root directory is returned.
     /// The entries are consumed.
     /// The leaf directory metadata is written to the header.
-    fn build_directories(&mut self) -> PmtResult<Directory> {
+    fn build_directories(&mut self, compressor: &dyn Compressor) -> PmtResult<Directory> {
         if !self.header.clustered {
             // Spec does only say that leaf directories *should* be in ascending order,
             // but sorted directories are better for readers anyway.
             self.entries.sort_by_key(|entry| entry.tile_id);
         }
-        let (root_dir, leaf_dirs) = self.optimize_directories(MAX_ROOT_DIR_BYTES)?;
+        let (root_dir, leaf_dirs) = self.optimize_directories(MAX_ROOT_DIR_BYTES, compressor)?;
         let mut leaves_bytes = 0usize;
 
         // If we have leaf directories, record their starting offset before writing them.
@@ -335,9 +363,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
         }
 
         for leaf in &leaf_dirs {
-            let leaf_bytes =
-                leaf.write_compressed_to_counted(&mut self.out, self.header.internal_compression)?;
-            leaves_bytes += leaf_bytes;
+            leaves_bytes += leaf.write_compressed_to_counted(&mut self.out, compressor)?;
         }
 
         self.header.leaf_length = leaves_bytes as u64;
@@ -347,6 +373,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     fn optimize_directories(
         &mut self,
         target_root_len: usize,
+        compressor: &dyn Compressor,
     ) -> PmtResult<(Directory, Vec<Directory>)> {
         // Same logic as go-pmtiles (https://github.com/protomaps/go-pmtiles/blob/f1c24e6/pmtiles/directory.go#L368-L396)
         // and planetiler (https://github.com/onthegomap/planetiler/blob/6b3e152/planetiler-core/src/main/java/com/onthegomap/planetiler/pmtiles/WriteablePmtiles.java#L96-L118)
@@ -355,7 +382,7 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
         if self.entries.len() < 16_384 {
             // we don't need self.entries anymore, so we'll put it in the root_dir directly
             let root_dir = Directory::from_entries(std::mem::take(&mut self.entries));
-            let root_bytes = root_dir.compressed_size(self.header.internal_compression)?;
+            let root_bytes = root_dir.compressed_size(compressor)?;
             if root_bytes <= target_root_len {
                 return Ok((root_dir, vec![]));
             }
@@ -370,8 +397,8 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
 
         let mut leaf_size = (self.entries.len() / 3500).max(4096);
         loop {
-            let (root_dir, leaf_dirs) = self.build_roots_leaves(leaf_size)?;
-            let root_bytes = root_dir.compressed_size(self.header.internal_compression)?;
+            let (root_dir, leaf_dirs) = self.build_roots_leaves(leaf_size, compressor)?;
+            let root_bytes = root_dir.compressed_size(compressor)?;
             if root_bytes <= target_root_len {
                 return Ok((root_dir, leaf_dirs));
             }
@@ -382,13 +409,17 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     /// Build root directory and leaf directories from entries, given a leaf size.
     /// The leaf directories are not written to output.
     /// The root directory is returned.
-    fn build_roots_leaves(&self, leaf_size: usize) -> PmtResult<(Directory, Vec<Directory>)> {
+    fn build_roots_leaves(
+        &self,
+        leaf_size: usize,
+        compressor: &dyn Compressor,
+    ) -> PmtResult<(Directory, Vec<Directory>)> {
         let mut root_dir = Directory::with_capacity(self.entries.len() / leaf_size);
         let mut leaves = Vec::with_capacity(self.entries.len() / leaf_size);
         let mut offset = 0;
         for chunk in self.entries.chunks(leaf_size) {
             let leaf = Directory::from_entries(chunk.to_vec());
-            let leaf_size = leaf.compressed_size(self.header.internal_compression)?;
+            let leaf_size = leaf.compressed_size(compressor)?;
             leaves.push(leaf);
 
             root_dir.push(DirEntry {
@@ -402,7 +433,9 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
 
         Ok((root_dir, leaves))
     }
+}
 
+impl<W: Write + Seek> PmTilesStreamWriter<W> {
     /// Finish writing the `PMTiles` file.
     ///
     /// # Errors
@@ -411,27 +444,30 @@ impl<W: Write + Seek> PmTilesStreamWriter<W> {
     /// - writing to the output stream fails or
     /// - if the file structure is invalid.
     pub fn finalize(mut self) -> PmtResult<()> {
+        let state = &mut self.state;
+
         // We're done writing data, so we can set the data_length here.
-        self.header.data_length =
-            self.out.writer_bytes() as u64 - MAX_INITIAL_BYTES as u64 - self.header.metadata_length;
+        state.header.data_length = state.out.writer_bytes() as u64
+            - MAX_INITIAL_BYTES as u64
+            - state.header.metadata_length;
 
         // Write leaf directories and get a root directory
-        let root_dir = self.build_directories()?;
+        let root_dir = state.build_directories(&*self.internal_compressor)?;
 
-        self.header.n_addressed_tiles = self.n_addressed_tiles.try_into().ok();
-        self.header.n_tile_contents = (self.tile_content_map.len() as u64).try_into().ok();
-        self.header.n_tile_entries = self.n_tile_entries.try_into().ok();
+        state.header.n_addressed_tiles = state.n_addressed_tiles.try_into().ok();
+        state.header.n_tile_contents = (state.tile_content_map.len() as u64).try_into().ok();
+        state.header.n_tile_entries = state.n_tile_entries.try_into().ok();
 
         // Determine compressed root directory length
         let mut root_dir_buf = vec![];
-        root_dir.write_compressed_to(&mut root_dir_buf, self.header.internal_compression)?;
-        self.header.root_length = root_dir_buf.len() as u64;
+        root_dir.write_compressed_to(&mut root_dir_buf, &*self.internal_compressor)?;
+        state.header.root_length = root_dir_buf.len() as u64;
 
         // Write header and root directory
-        self.out.rewind()?;
-        self.header.write_to(&mut self.out)?;
-        self.out.write_all(&root_dir_buf)?;
-        self.out.flush()?;
+        state.out.rewind()?;
+        state.header.write_to(&mut state.out)?;
+        state.out.write_all(&root_dir_buf)?;
+        state.out.flush()?;
 
         Ok(())
     }
@@ -455,7 +491,8 @@ mod tests {
 
     use crate::tests::RASTER_FILE;
     use crate::{
-        AsyncPmTilesReader, Compression, MmapBackend, PmTilesWriter, TileCoord, TileId, TileType,
+        AsyncPmTilesReader, Compression, GzipCompressor, MmapBackend, PmTilesWriter, TileCoord,
+        TileId, TileType,
     };
 
     fn get_temp_file_path(suffix: &str) -> std::io::Result<String> {
@@ -482,9 +519,7 @@ mod tests {
         for id in 0..num_tiles.into() {
             let id = TileId::new(id).unwrap();
             let tile = tiles_in.get_tile(id).await.unwrap().unwrap();
-            writer
-                .add_tile_by_id(id, &tile, header_in.tile_compression)
-                .unwrap();
+            writer.add_raw_tile(id.into(), &tile).unwrap();
         }
         writer.finalize().unwrap();
 
@@ -590,19 +625,15 @@ mod tests {
         let file = get_temp_file_path("pmtiles").unwrap();
         let file = File::create(file).unwrap();
         let mut writer = PmTilesWriter::new(TileType::Png).create(file).unwrap();
-        assert_eq!(writer.header.tile_compression, Compression::None);
+        assert_eq!(writer.state.header.tile_compression, Compression::None);
 
         let id = TileId::new(2).unwrap();
-        writer
-            .add_tile_by_id(id, &[0, 1, 2, 3], Compression::None)
-            .unwrap();
-        assert!(writer.header.clustered);
+        writer.add_tile(id.into(), &[0, 1, 2, 3]).unwrap();
+        assert!(writer.state.header.clustered);
 
         let id = TileId::new(0).unwrap();
-        writer
-            .add_tile_by_id(id, &[0, 1, 2, 3], Compression::None)
-            .unwrap();
-        assert!(!writer.header.clustered);
+        writer.add_tile(id.into(), &[0, 1, 2, 3]).unwrap();
+        assert!(!writer.state.header.clustered);
 
         writer.finalize().unwrap();
     }
@@ -764,5 +795,232 @@ mod tests {
 
         // B should point to different bytes.
         assert_ne!(e1.offset, e0.offset);
+    }
+
+    #[cfg(feature = "zstd")]
+    #[tokio::test]
+    async fn zstd_compressor_roundtrip() {
+        use crate::{Compressor, ZstdCompressor};
+
+        let test_data = b"hello pmtiles zstd compressor with custom level";
+
+        // Verify custom level produces different output than default
+        let custom = ZstdCompressor(19);
+        let default = ZstdCompressor::default();
+        let mut custom_buf = Vec::new();
+        let mut default_buf = Vec::new();
+        custom.compress(test_data, &mut custom_buf).unwrap();
+        default.compress(test_data, &mut default_buf).unwrap();
+        assert_ne!(
+            custom_buf, default_buf,
+            "custom level should differ from default"
+        );
+        assert!(
+            custom_buf.len() < default_buf.len(),
+            "level 19 should compress better than default"
+        );
+
+        let path = get_temp_file_path("pmtiles").unwrap();
+        let file = File::create(&path).unwrap();
+        let mut writer = PmTilesWriter::new(TileType::Mvt)
+            .tile_codec(ZstdCompressor(19))
+            .create(file)
+            .unwrap();
+
+        let tile_id = TileId::new(0).unwrap();
+        writer.add_tile(tile_id.into(), test_data).unwrap();
+        writer.finalize().unwrap();
+
+        let backend = MmapBackend::try_from(&path).await.unwrap();
+        let tiles_out = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        assert_eq!(tiles_out.get_header().tile_compression, Compression::Zstd);
+
+        let tile = tiles_out
+            .get_tile_decompressed(tile_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*tile, test_data);
+    }
+
+    #[tokio::test]
+    async fn gzip_compressor_best_roundtrip() {
+        use crate::Compressor;
+
+        let test_data = b"hello pmtiles gzip best compressor with enough data to see a difference";
+
+        // Verify best compression produces different output than default
+        let custom = GzipCompressor(flate2::Compression::best());
+        let default = GzipCompressor::default();
+        let mut custom_buf = Vec::new();
+        let mut default_buf = Vec::new();
+        custom.compress(test_data, &mut custom_buf).unwrap();
+        default.compress(test_data, &mut default_buf).unwrap();
+        assert_ne!(
+            custom_buf, default_buf,
+            "best level should differ from default"
+        );
+        assert!(
+            custom_buf.len() <= default_buf.len(),
+            "best should compress at least as well as default"
+        );
+
+        let path = get_temp_file_path("pmtiles").unwrap();
+        let file = File::create(&path).unwrap();
+        let mut writer = PmTilesWriter::new(TileType::Mvt)
+            .tile_codec(GzipCompressor(flate2::Compression::best()))
+            .create(file)
+            .unwrap();
+
+        let tile_id = TileId::new(0).unwrap();
+        writer.add_tile(tile_id.into(), test_data).unwrap();
+        writer.finalize().unwrap();
+
+        let backend = MmapBackend::try_from(&path).await.unwrap();
+        let tiles_out = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        assert_eq!(tiles_out.get_header().tile_compression, Compression::Gzip);
+
+        let tile = tiles_out
+            .get_tile_decompressed(tile_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*tile, test_data);
+    }
+
+    #[tokio::test]
+    async fn custom_compressor_roundtrip() {
+        use crate::writer::compressor::{Compressor, NoCompression};
+
+        /// A custom compressor that just delegates to `NoCompression`
+        /// but reports itself as Gzip (for testing the trait mechanism).
+        struct CustomTestCompressor;
+
+        impl Compressor for CustomTestCompressor {
+            fn compression(&self) -> Compression {
+                // Use None so we can read back without decompression issues
+                Compression::None
+            }
+
+            fn compress(
+                &self,
+                input: &[u8],
+                output: &mut dyn std::io::Write,
+            ) -> crate::PmtResult<()> {
+                NoCompression.compress(input, output)
+            }
+        }
+
+        let path = get_temp_file_path("pmtiles").unwrap();
+        let file = File::create(&path).unwrap();
+        let mut writer = PmTilesWriter::new(TileType::Png)
+            .tile_codec(CustomTestCompressor)
+            .create(file)
+            .unwrap();
+
+        let test_data = b"custom compressor test data";
+        let tile_id = TileId::new(0).unwrap();
+        writer.add_tile(tile_id.into(), test_data).unwrap();
+        writer.finalize().unwrap();
+
+        let backend = MmapBackend::try_from(&path).await.unwrap();
+        let tiles_out = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+
+        let tile = tiles_out.get_tile(tile_id).await.unwrap().unwrap();
+        assert_eq!(&*tile, test_data);
+    }
+
+    #[cfg(feature = "brotli")]
+    #[tokio::test]
+    async fn brotli_compressor_roundtrip() {
+        use crate::{BrotliCompressor, Compressor};
+
+        let test_data = b"hello pmtiles brotli compressor with enough data to see a difference";
+
+        // Verify custom quality produces different output than default
+        let custom = BrotliCompressor(brotli::enc::BrotliEncoderParams {
+            quality: 5,
+            ..Default::default()
+        });
+        let default = BrotliCompressor::default();
+        let mut custom_buf = Vec::new();
+        let mut default_buf = Vec::new();
+        custom.compress(test_data, &mut custom_buf).unwrap();
+        default.compress(test_data, &mut default_buf).unwrap();
+        assert_ne!(
+            custom_buf, default_buf,
+            "custom quality should differ from default"
+        );
+        assert!(
+            custom_buf.len() > default_buf.len(),
+            "quality 5 should compress worse than default (quality 11)"
+        );
+
+        let path = get_temp_file_path("pmtiles").unwrap();
+        let file = File::create(&path).unwrap();
+        let mut writer = PmTilesWriter::new(TileType::Mvt)
+            .tile_codec(custom)
+            .create(file)
+            .unwrap();
+
+        let tile_id = TileId::new(0).unwrap();
+        writer.add_tile(tile_id.into(), test_data).unwrap();
+        writer.finalize().unwrap();
+
+        let backend = MmapBackend::try_from(&path).await.unwrap();
+        let tiles_out = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        assert_eq!(tiles_out.get_header().tile_compression, Compression::Brotli);
+
+        let tile = tiles_out
+            .get_tile_decompressed(tile_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*tile, test_data);
+    }
+
+    #[tokio::test]
+    async fn internal_codec_roundtrip() {
+        let test_metadata = r#"{"name":"test","description":"internal codec test"}"#;
+
+        let path = get_temp_file_path("pmtiles").unwrap();
+        let file = File::create(&path).unwrap();
+        let mut writer = PmTilesWriter::new(TileType::Mvt)
+            .internal_codec(GzipCompressor(flate2::Compression::best()))
+            .metadata(test_metadata)
+            .create(file)
+            .unwrap();
+
+        for tile_id in 0..100u64 {
+            let data: Vec<u8> = tile_id.to_le_bytes().to_vec();
+            writer
+                .add_tile(TileId::new(tile_id).unwrap().into(), &data)
+                .unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let backend = MmapBackend::try_from(&path).await.unwrap();
+        let tiles_out = Arc::new(AsyncPmTilesReader::try_from_source(backend).await.unwrap());
+
+        let header = tiles_out.get_header();
+        assert_eq!(header.internal_compression, Compression::Gzip);
+
+        let metadata_out = tiles_out.get_metadata().await.unwrap();
+        assert_eq!(metadata_out, test_metadata);
+
+        let entries = tiles_out
+            .clone()
+            .entries()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 100);
+
+        let tile_0 = tiles_out
+            .get_tile_decompressed(TileId::new(0).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(*tile_0, 0u64.to_le_bytes());
     }
 }

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -63,6 +63,19 @@ struct WriterState<W: Write + Seek> {
     prev_written_tile_offset: u64,
 }
 
+/// Sized wrapper around `&mut dyn Write` so it can be passed to generic `W: Write` methods.
+struct DynWriter<'a>(&'a mut dyn Write);
+
+impl Write for DynWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
 pub(crate) trait WriteTo {
     fn write_to<W: Write>(&self, writer: &mut W) -> std::io::Result<()>;
 
@@ -71,10 +84,9 @@ pub(crate) trait WriteTo {
         writer: &mut W,
         compressor: &dyn Compressor,
     ) -> PmtResult<()> {
-        let mut buf = Vec::new();
-        self.write_to(&mut buf)?;
-        compressor.compress(&buf, writer)?;
-        Ok(())
+        compressor.compress(writer, &mut |encoder| {
+            self.write_to(&mut DynWriter(encoder))
+        })
     }
 
     fn write_compressed_to_counted<W: Write>(
@@ -870,10 +882,10 @@ mod tests {
 
             fn compress(
                 &self,
-                input: &[u8],
                 output: &mut dyn std::io::Write,
+                input: &mut dyn FnMut(&mut dyn std::io::Write) -> std::io::Result<()>,
             ) -> crate::PmtResult<()> {
-                NoCompression.compress(input, output)
+                NoCompression.compress(output, input)
             }
         }
 


### PR DESCRIPTION
I needed to change parameters to Zstd and thought it might be worth making this extensible rather than adding more config surface.

This introduces a `Compressor` trait that allows configuring compression parameters or providing entirely custom compression implementations. The existing `tile_compression()` and `internal_compression()` builders continue to work as before with default parameters.

New API

- `Compressor` trait with `compression()` and `compress()` methods
- Built-in implementations: `NoCompression`, `GzipCompressor`, `BrotliCompressor`, `ZstdCompressor`
- `tile_codec()` and `internal_codec()` builder methods on `PmTilesWriter` that accept any `Compressor` impl

Example

```rust
  use pmtiles::{PmTilesWriter, ZstdCompressor, TileType};

  let writer = PmTilesWriter::new(TileType::Mvt)
      .tile_codec(ZstdCompressor(19))
      .create(file)?;
```

Other changes

- Split writer.rs into writer/mod.rs and writer/compressor.rs
- `Compressor::compress` returns `PmtResult` for consistency with existing error types
- `impl From<Compression> for Box<dyn Compressor>` for ergonomic default compressor construction
