### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.21.0...v0.22.0) - 2026-04-18
+
+### Fixed
+
+- directory offset encoding ([#111](https://github.com/stadiamaps/pmtiles-rs/pull/111))
+
+### Other
+
+- update object_store dependency and fix build ([#119](https://github.com/stadiamaps/pmtiles-rs/pull/119))
+- Configurable compression parameters via Compressor trait ([#112](https://github.com/stadiamaps/pmtiles-rs/pull/112))
+
 ## [0.21.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.20.0...v0.21.0) - 2026-03-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `pmtiles`: 0.21.0 -> 0.22.0 (⚠ API breaking changes)

### ⚠ `pmtiles` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type PmTilesWriter is no longer Send, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:23
  type PmTilesWriter is no longer Sync, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:23
  type PmTilesWriter is no longer UnwindSafe, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:23
  type PmTilesWriter is no longer RefUnwindSafe, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:23
  type PmTilesStreamWriter is no longer Send, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:36
  type PmTilesStreamWriter is no longer Sync, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:36
  type PmTilesStreamWriter is no longer UnwindSafe, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:36
  type PmTilesStreamWriter is no longer RefUnwindSafe, in /tmp/.tmpQE4q9u/pmtiles-rs/src/writer/mod.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.21.0...v0.22.0) - 2026-04-18

### Fixed

- directory offset encoding ([#111](https://github.com/stadiamaps/pmtiles-rs/pull/111))

### Other

- update object_store dependency and fix build ([#119](https://github.com/stadiamaps/pmtiles-rs/pull/119))
- Configurable compression parameters via Compressor trait ([#112](https://github.com/stadiamaps/pmtiles-rs/pull/112))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).