### PR TITLE
feat!: teach AsyncPmTilesReader to check data version strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ rstest = "0.26.1"
 tempfile = "3.13.0"
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
 url = "2"
+mockito = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ flate2 = { version = "1", optional = true }
 fmmap = { version = "0.4", default-features = false, optional = true }
 futures-util = { version = "0.3", optional = true }
 moka = { version = "0.12", optional = true, features = ["future"] }
-object_store = { version = "0.13", optional = true, default-features = false }
+object_store = { version = "0.13", optional = true, default-features = false, features = ["tokio"] }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
 rust-s3 = { version = "0.37.0", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -55,6 +55,7 @@ pub struct AsyncPmTilesReader<B, C = NoCache> {
     cache: C,
     header: Header,
     root_directory: Directory,
+    initial_data_version_string: Option<String>,
 }
 
 impl<B: AsyncBackend + Sync + Send> AsyncPmTilesReader<B, NoCache> {
@@ -86,6 +87,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         // Read the first 127 and up to 16,384 bytes to ensure we can initialize the header and root directory.
         let initial_response = backend.read(0, MAX_INITIAL_BYTES).await?;
         let mut initial_bytes = initial_response.bytes;
+        let initial_data_version_string = initial_response.data_version_string;
         if initial_bytes.len() < HEADER_SIZE {
             return Err(PmtError::InvalidHeader);
         }
@@ -104,6 +106,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
             cache,
             header,
             root_directory,
+            initial_data_version_string,
         })
     }
 
@@ -127,6 +130,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
     /// This function will return an error if the
     /// - header/root directory cannot be read or
     /// - backend fails to read tile data
+    /// - underlying `PMTiles` archive has changed since initialization
     pub async fn get_tile<Id: Into<TileId>>(&self, tile_id: Id) -> PmtResult<Option<Bytes>> {
         let Some(entry) = self.find_tile_entry(tile_id.into()).await? else {
             return Ok(None);
@@ -134,8 +138,27 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
         let offset = (self.header.data_offset + entry.offset) as _;
         let length = entry.length as _;
+        let backend_response = self.backend.read_exact(offset, length).await?;
 
-        Ok(Some(self.backend.read_exact(offset, length).await?.bytes))
+        // Compare the initial data version string (stored at instantiation time based on the `PMTiles` metadata)
+        // against the latest version string, but only if both are set.
+        //
+        // If an initial data version string was not available, the backend does not support exposing version strings.
+        // If a current data version string is not available, this request was unable to extract a data version string,
+        // and the check should be skipped.
+        match (
+            &self.initial_data_version_string,
+            &backend_response.data_version_string,
+        ) {
+            (Some(expected), Some(actual)) => {
+                if expected != actual {
+                    return Err(PmtError::SourceModified);
+                }
+            }
+            _ => (),
+        }
+
+        Ok(Some(backend_response.bytes))
     }
 
     /// Fetches tile bytes from the archive.

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -498,9 +498,10 @@ mod tests {
     async fn test_data_version_source_modified() {
         // Tests that if the underlying storage object changes after initial read of a
         // pmtiles header, a subsequent read will fail.
+        use std::sync::Arc;
+
         use object_store::path::Path;
         use object_store::{ObjectStore, PutOptions, PutPayload};
-        use std::sync::Arc;
 
         // The test uses the ObjectStoreBackend with an InMemory underlying store since that
         // makes it easy to modify the ETag of a stored object by putting a new "version".

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -146,9 +146,10 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         // If an initial data version string was not available, the backend does not support exposing version strings.
         // If a current data version string is not available, this request was unable to extract a data version string,
         // and the check should be skipped.
-        if let Some(expected) = &self.initial_data_version_string
-            && let Some(actual) = &backend_response.data_version_string
-            && expected != actual
+        if let (Some(expected), Some(actual)) = (
+            &self.initial_data_version_string,
+            &backend_response.data_version_string,
+        ) && expected != actual
         {
             return Err(PmtError::SourceModified);
         }

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -146,16 +146,11 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         // If an initial data version string was not available, the backend does not support exposing version strings.
         // If a current data version string is not available, this request was unable to extract a data version string,
         // and the check should be skipped.
-        match (
-            &self.initial_data_version_string,
-            &backend_response.data_version_string,
-        ) {
-            (Some(expected), Some(actual)) => {
-                if expected != actual {
-                    return Err(PmtError::SourceModified);
-                }
-            }
-            _ => (),
+        if let Some(expected) = &self.initial_data_version_string
+            && let Some(actual) = &backend_response.data_version_string
+            && expected != actual
+        {
+            return Err(PmtError::SourceModified);
         }
 
         Ok(Some(backend_response.bytes))

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -135,7 +135,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
         let offset = (self.header.data_offset + entry.offset) as _;
         let length = entry.length as _;
 
-        Ok(Some(self.backend.read_exact(offset, length).await?))
+        Ok(Some(self.backend.read_exact(offset, length).await?.bytes))
     }
 
     /// Fetches tile bytes from the archive.
@@ -177,7 +177,8 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
     pub async fn get_metadata(&self) -> PmtResult<String> {
         let offset = self.header.metadata_offset as _;
         let length = self.header.metadata_length as _;
-        let metadata = self.backend.read_exact(offset, length).await?;
+        let response = self.backend.read_exact(offset, length).await?;
+        let metadata = response.bytes;
 
         let decompressed_metadata =
             Self::decompress(self.header.internal_compression, metadata).await?;
@@ -326,7 +327,7 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
 
     async fn read_directory(&self, offset: usize, length: usize) -> PmtResult<Directory> {
         let data = self.backend.read_exact(offset, length).await?;
-        Self::read_compressed_directory(self.header.internal_compression, data).await
+        Self::read_compressed_directory(self.header.internal_compression, data.bytes).await
     }
 
     async fn read_compressed_directory(
@@ -378,7 +379,7 @@ pub trait AsyncBackend {
         &self,
         offset: usize,
         length: usize,
-    ) -> impl Future<Output = PmtResult<Bytes>> + Send
+    ) -> impl Future<Output = PmtResult<BackendResponse>> + Send
     where
         Self: Sync,
     {
@@ -392,7 +393,7 @@ pub trait AsyncBackend {
                 ));
             }
 
-            Ok(response.bytes)
+            Ok(response)
         }
     }
 

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -497,6 +497,49 @@ mod tests {
         assert_eq!(tile, fixture_bytes, "Expected tile to match fixture.");
     }
 
+    #[tokio::test]
+    #[cfg(feature = "object-store")]
+    async fn test_data_version_source_modified() {
+        // Tests that if the underlying storage object changes after initial read of a
+        // pmtiles header, a subsequent read will fail.
+        use object_store::path::Path;
+        use object_store::{ObjectStore, PutOptions, PutPayload};
+        use std::sync::Arc;
+
+        // The test uses the ObjectStoreBackend with an InMemory underlying store since that
+        // makes it easy to modify the ETag of a stored object by putting a new "version".
+        use crate::ObjectStoreBackend;
+
+        // The exact file here does not matter - it is only important that we fetch a valid
+        // tile below.
+        let data: &[u8] = include_bytes!("../fixtures/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles");
+        let store = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("file.pmtiles");
+
+        let payload: PutPayload = bytes::Bytes::copy_from_slice(data).into();
+        store
+            .put_opts(&path, payload, PutOptions::default())
+            .await
+            .unwrap();
+
+        // Create the AsyncReader and fetch a tile. The first tile fetch will succeed.
+        let backend = ObjectStoreBackend::new(Box::new(store.as_ref().clone()), path.clone());
+        let tiles = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        let result = tiles.get_tile(id(0, 0, 0)).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
+
+        // Overwrite the object — InMemory underlying storage will increment the ETag.
+        let payload: PutPayload = bytes::Bytes::copy_from_slice(data).into();
+        store
+            .put_opts(&path, payload, PutOptions::default())
+            .await
+            .unwrap();
+
+        let result = tiles.get_tile(id(0, 0, 0)).await;
+        assert!(matches!(result, Err(crate::PmtError::SourceModified)));
+    }
+
     #[rstest]
     #[case(id(6, 31, 23), false)] // missing tile
     #[case(id(12, 2174, 1492), true)] // existing leaf tile

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -21,6 +21,7 @@ use crate::{Compression, DirEntry, Directory, Header, PmtError, PmtResult, TileI
 use crate::{DirectoryCache, NoCache};
 
 /// The response from a backend [`AsyncBackend::read`] call.
+#[derive(Debug)]
 pub struct BackendResponse {
     /// The bytes read from the backend.
     pub bytes: Bytes,

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -83,7 +83,8 @@ impl<B: AsyncBackend + Sync + Send, C: DirectoryCache + Sync + Send> AsyncPmTile
     /// - or if the root directory is malformed
     pub async fn try_from_cached_source(backend: B, cache: C) -> PmtResult<Self> {
         // Read the first 127 and up to 16,384 bytes to ensure we can initialize the header and root directory.
-        let mut initial_bytes = backend.read(0, MAX_INITIAL_BYTES).await?;
+        let initial_response = backend.read(0, MAX_INITIAL_BYTES).await?;
+        let mut initial_bytes = initial_response.bytes;
         if initial_bytes.len() < HEADER_SIZE {
             return Err(PmtError::InvalidHeader);
         }
@@ -381,21 +382,25 @@ pub trait AsyncBackend {
         Self: Sync,
     {
         async move {
-            let data = self.read(offset, length).await?;
+            let response = self.read(offset, length).await?;
 
-            if data.len() == length {
-                Ok(data)
-            } else {
-                Err(PmtError::UnexpectedNumberOfBytesReturned(
+            if response.bytes.len() != length {
+                return Err(PmtError::UnexpectedNumberOfBytesReturned(
                     length,
-                    data.len(),
-                ))
+                    response.bytes.len(),
+                ));
             }
+
+            Ok(response.bytes)
         }
     }
 
     /// Reads up to `length` bytes starting at `offset`.
-    fn read(&self, offset: usize, length: usize) -> impl Future<Output = PmtResult<Bytes>> + Send;
+    fn read(
+        &self,
+        offset: usize,
+        length: usize,
+    ) -> impl Future<Output = PmtResult<BackendResponse>> + Send;
 }
 
 #[cfg(test)]

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -20,6 +20,34 @@ use crate::{Compression, DirEntry, Directory, Header, PmtError, PmtResult, TileI
 #[cfg(feature = "__async")]
 use crate::{DirectoryCache, NoCache};
 
+/// The response from a backend [`AsyncBackend::read`] call.
+pub struct BackendResponse {
+    /// The bytes read from the backend.
+    pub bytes: Bytes,
+    /// An optional version string for detecting source data changes (e.g. HTTP ETags).
+    /// A None means the backend does not have a way of discriminating PMTiles data versions
+    /// or a data version was not able to be acquired for a given request.
+    pub data_version_string: Option<String>,
+}
+
+impl BackendResponse {
+    /// Creates a `BackendResponse` with no version string.
+    pub fn new(bytes: Bytes) -> Self {
+        Self {
+            bytes,
+            data_version_string: None,
+        }
+    }
+
+    /// Creates a `BackendResponse` with a version string.
+    pub fn new_with_version(bytes: Bytes, data_version_string: String) -> Self {
+        Self {
+            bytes,
+            data_version_string: Some(data_version_string),
+        }
+    }
+}
+
 /// An asynchronous reader for `PMTiles` archives.
 pub struct AsyncPmTilesReader<B, C = NoCache> {
     backend: B,

--- a/src/async_reader.rs
+++ b/src/async_reader.rs
@@ -25,9 +25,9 @@ use crate::{DirectoryCache, NoCache};
 pub struct BackendResponse {
     /// The bytes read from the backend.
     pub bytes: Bytes,
-    /// An optional version string for detecting source data changes (e.g. HTTP ETags).
-    /// A None means the backend does not have a way of discriminating PMTiles data versions
-    /// or a data version was not able to be acquired for a given request.
+    /// An optional version string for detecting source data changes (e.g. HTTP E-Tags).
+    /// A None means the backend does not have a way of discriminating `PMTiles` data versions
+    /// or a data version was not able to be acquired for this request.
     pub data_version_string: Option<String>,
 }
 

--- a/src/backends/aws_s3.rs
+++ b/src/backends/aws_s3.rs
@@ -73,7 +73,7 @@ impl AsyncBackend for AwsS3Backend {
         let range_end = offset + length - 1;
         let range = format!("bytes={offset}-{range_end}");
 
-        let obj = self
+        let mut obj = self
             .client
             .get_object()
             .bucket(self.bucket.clone())
@@ -83,10 +83,12 @@ impl AsyncBackend for AwsS3Backend {
             .await
             .map_err(Box::new)?;
 
-        let data_version = obj
-            .e_tag()
-            .map(str::to_owned)
-            .or_else(|| obj.last_modified.map(|d| d.to_string()));
+        let mut data_version = obj.e_tag.take();
+        if data_version.is_none()
+            && let Some(last_modified) = obj.last_modified
+        {
+            data_version = Some(last_modified.to_string());
+        }
 
         let response_bytes = obj
             .body

--- a/src/backends/aws_s3.rs
+++ b/src/backends/aws_s3.rs
@@ -83,12 +83,10 @@ impl AsyncBackend for AwsS3Backend {
             .await
             .map_err(Box::new)?;
 
-        let mut data_version = obj.e_tag.take();
-        if data_version.is_none()
-            && let Some(last_modified) = obj.last_modified
-        {
-            data_version = Some(last_modified.to_string());
-        }
+        let data_version = obj
+            .e_tag
+            .take()
+            .or_else(|| obj.last_modified.as_ref().map(|v| v.to_string()));
 
         let response_bytes = obj
             .body

--- a/src/backends/aws_s3.rs
+++ b/src/backends/aws_s3.rs
@@ -83,6 +83,11 @@ impl AsyncBackend for AwsS3Backend {
             .await
             .map_err(Box::new)?;
 
+        let data_version = obj
+            .e_tag()
+            .map(str::to_owned)
+            .or_else(|| obj.last_modified.map(|d| d.to_string()));
+
         let response_bytes = obj
             .body
             .collect()
@@ -93,7 +98,10 @@ impl AsyncBackend for AwsS3Backend {
         if response_bytes.len() > length {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(BackendResponse::new(response_bytes))
+            Ok(match data_version {
+                Some(v) => BackendResponse::new_with_version(response_bytes, v),
+                None => BackendResponse::new(response_bytes),
+            })
         }
     }
 }

--- a/src/backends/aws_s3.rs
+++ b/src/backends/aws_s3.rs
@@ -86,7 +86,7 @@ impl AsyncBackend for AwsS3Backend {
         let data_version = obj
             .e_tag
             .take()
-            .or_else(|| obj.last_modified.as_ref().map(|v| v.to_string()));
+            .or_else(|| obj.last_modified.as_ref().map(ToString::to_string));
 
         let response_bytes = obj
             .body

--- a/src/backends/aws_s3.rs
+++ b/src/backends/aws_s3.rs
@@ -1,6 +1,8 @@
 use aws_sdk_s3::Client;
 
-use crate::{AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtError, PmtResult};
+use crate::{
+    AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtError, PmtResult,
+};
 
 impl AsyncPmTilesReader<AwsS3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a client, bucket and key to the

--- a/src/backends/aws_s3.rs
+++ b/src/backends/aws_s3.rs
@@ -1,7 +1,6 @@
 use aws_sdk_s3::Client;
-use bytes::Bytes;
 
-use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtError, PmtResult};
+use crate::{AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtError, PmtResult};
 
 impl AsyncPmTilesReader<AwsS3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a client, bucket and key to the
@@ -68,7 +67,7 @@ impl AwsS3Backend {
 }
 
 impl AsyncBackend for AwsS3Backend {
-    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         let range_end = offset + length - 1;
         let range = format!("bytes={offset}-{range_end}");
 
@@ -92,7 +91,7 @@ impl AsyncBackend for AwsS3Backend {
         if response_bytes.len() > length {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(response_bytes)
+            Ok(BackendResponse::new(response_bytes))
         }
     }
 }

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -110,4 +110,62 @@ mod tests {
 
         AsyncPmTilesReader::try_from_source(backend).await.unwrap();
     }
+
+    async fn make_backend(server: &mockito::Server) -> HttpBackend {
+        HttpBackend::try_from(Client::new(), server.url()).expect("valid url")
+    }
+
+    #[tokio::test]
+    async fn read_no_data_version_header() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .match_header("range", mockito::Matcher::Any)
+            .with_status(206)
+            .with_body(vec![0u8; 64])
+            .create_async()
+            .await;
+
+        let backend = make_backend(&server).await;
+        let response = backend.read(0, 64).await.expect("read succeeded");
+        assert!(response.data_version_string.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_prefers_etag_over_last_modified() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .match_header("range", mockito::Matcher::Any)
+            .with_status(206)
+            .with_header("ETag", "\"abc123\"")
+            .with_header("Last-Modified", "Wed, 01 Jan 2025 00:00:00 GMT")
+            .with_body(vec![0u8; 64])
+            .create_async()
+            .await;
+
+        let backend = make_backend(&server).await;
+        let response = backend.read(0, 64).await.expect("read succeeded");
+        assert_eq!(response.data_version_string.as_deref(), Some("\"abc123\""));
+    }
+
+    #[tokio::test]
+    async fn read_falls_back_to_last_modified() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .match_header("range", mockito::Matcher::Any)
+            .with_status(206)
+            .with_header("Last-Modified", "Wed, 01 Jan 2025 00:00:00 GMT")
+            .with_body(vec![0u8; 64])
+            .create_async()
+            .await;
+
+        let backend = make_backend(&server).await;
+        let response = backend.read(0, 64).await.expect("read succeeded");
+        assert_eq!(
+            response.data_version_string.as_deref(),
+            Some("Wed, 01 Jan 2025 00:00:00 GMT")
+        );
+    }
 }

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -1,4 +1,4 @@
-use reqwest::header::{HeaderValue, RANGE};
+use reqwest::header::{ETAG, HeaderValue, LAST_MODIFIED, RANGE};
 use reqwest::{Client, IntoUrl, Method, Request, StatusCode, Url};
 
 use crate::{
@@ -77,12 +77,21 @@ impl AsyncBackend for HttpBackend {
             return Err(PmtError::RangeRequestsUnsupported);
         }
 
+        let headers = response.headers();
+        let data_version_header_value = headers.get(ETAG).or(headers.get(LAST_MODIFIED));
+        let data_version_string = data_version_header_value
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+
         let response_bytes = response.bytes().await?;
 
         if response_bytes.len() > length {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(BackendResponse::new(response_bytes))
+            Ok(match data_version_string {
+                Some(v) => BackendResponse::new_with_version(response_bytes, v.to_string()),
+                None => BackendResponse::new(response_bytes),
+            })
         }
     }
 }

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -1,8 +1,9 @@
-use bytes::Bytes;
 use reqwest::header::{HeaderValue, RANGE};
 use reqwest::{Client, IntoUrl, Method, Request, StatusCode, Url};
 
-use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtError, PmtResult};
+use crate::{
+    AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtError, PmtResult,
+};
 
 impl AsyncPmTilesReader<HttpBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a URL using the Reqwest backend.
@@ -63,7 +64,7 @@ impl HttpBackend {
 }
 
 impl AsyncBackend for HttpBackend {
-    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         let end = offset + length - 1;
         let range = format!("bytes={offset}-{end}");
         let range = HeaderValue::try_from(range)?;
@@ -77,10 +78,11 @@ impl AsyncBackend for HttpBackend {
         }
 
         let response_bytes = response.bytes().await?;
+
         if response_bytes.len() > length {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(response_bytes)
+            Ok(BackendResponse::new(response_bytes))
         }
     }
 }

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -89,7 +89,7 @@ impl AsyncBackend for HttpBackend {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
             Ok(match data_version {
-                Some(v) => BackendResponse::new_with_version(response_bytes, v.to_string()),
+                Some(v) => BackendResponse::new_with_version(response_bytes, v.clone()),
                 None => BackendResponse::new(response_bytes),
             })
         }
@@ -111,7 +111,7 @@ mod tests {
         AsyncPmTilesReader::try_from_source(backend).await.unwrap();
     }
 
-    async fn make_backend(server: &mockito::Server) -> HttpBackend {
+    fn make_backend(server: &mockito::Server) -> HttpBackend {
         HttpBackend::try_from(Client::new(), server.url()).expect("valid url")
     }
 
@@ -126,7 +126,7 @@ mod tests {
             .create_async()
             .await;
 
-        let backend = make_backend(&server).await;
+        let backend = make_backend(&server);
         let response = backend.read(0, 64).await.expect("read succeeded");
         assert!(response.data_version_string.is_none());
     }
@@ -144,7 +144,7 @@ mod tests {
             .create_async()
             .await;
 
-        let backend = make_backend(&server).await;
+        let backend = make_backend(&server);
         let response = backend.read(0, 64).await.expect("read succeeded");
         assert_eq!(response.data_version_string.as_deref(), Some("\"abc123\""));
     }
@@ -161,7 +161,7 @@ mod tests {
             .create_async()
             .await;
 
-        let backend = make_backend(&server).await;
+        let backend = make_backend(&server);
         let response = backend.read(0, 64).await.expect("read succeeded");
         assert_eq!(
             response.data_version_string.as_deref(),

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -89,7 +89,7 @@ impl AsyncBackend for HttpBackend {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
             Ok(match data_version {
-                Some(v) => BackendResponse::new_with_version(response_bytes, v.clone()),
+                Some(v) => BackendResponse::new_with_version(response_bytes, v),
                 None => BackendResponse::new(response_bytes),
             })
         }

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -78,8 +78,8 @@ impl AsyncBackend for HttpBackend {
         }
 
         let headers = response.headers();
-        let data_version_header_value = headers.get(ETAG).or(headers.get(LAST_MODIFIED));
-        let data_version_string = data_version_header_value
+        let data_version_header_value = headers.get(ETAG).or_else(|| headers.get(LAST_MODIFIED));
+        let data_version = data_version_header_value
             .and_then(|v| v.to_str().ok())
             .map(str::to_owned);
 
@@ -88,7 +88,7 @@ impl AsyncBackend for HttpBackend {
         if response_bytes.len() > length {
             Err(PmtError::ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(match data_version_string {
+            Ok(match data_version {
                 Some(v) => BackendResponse::new_with_version(response_bytes, v.to_string()),
                 None => BackendResponse::new(response_bytes),
             })

--- a/src/backends/mmap.rs
+++ b/src/backends/mmap.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::path::Path;
 
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt as _, AsyncOptions};
 
 use crate::{
@@ -69,9 +69,11 @@ impl From<fmmap::error::Error> for PmtError {
 }
 
 impl AsyncBackend for MmapBackend {
-    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+    async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         if self.file.len() >= offset + length {
-            Ok(self.file.reader(offset)?.copy_to_bytes(length))
+            Ok(BackendResponse::new(
+                self.file.reader(offset)?.copy_to_bytes(length),
+            ))
         } else {
             Err(PmtError::Reading(io::Error::from(
                 io::ErrorKind::UnexpectedEof,

--- a/src/backends/mmap.rs
+++ b/src/backends/mmap.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use bytes::{Buf, Bytes};
 use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt as _, AsyncOptions};
 
-use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtError, PmtResult};
+use crate::{
+    AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtError, PmtResult,
+};
 
 impl AsyncPmTilesReader<MmapBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a file path using the async mmap backend.
@@ -77,11 +79,13 @@ impl AsyncBackend for MmapBackend {
         }
     }
 
-    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         let reader = self.file.reader(offset)?;
 
         let read_length = length.min(reader.len());
 
-        Ok(self.file.reader(offset)?.copy_to_bytes(read_length))
+        Ok(BackendResponse::new(
+            self.file.reader(offset)?.copy_to_bytes(read_length),
+        ))
     }
 }

--- a/src/backends/object_store.rs
+++ b/src/backends/object_store.rs
@@ -11,11 +11,10 @@
 
 use std::ops::Range;
 
-use bytes::Bytes;
 use object_store::ObjectStore;
 use object_store::path::Path;
 
-use crate::{AsyncBackend, PmtResult};
+use crate::{AsyncBackend, BackendResponse, PmtResult};
 
 /// Backend implementation using the [`object_store`] crate for unified storage access.
 ///
@@ -99,7 +98,7 @@ impl ObjectStoreBackend {
 }
 
 impl AsyncBackend for ObjectStoreBackend {
-    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         use object_store::ObjectStoreExt;
 
         let range = Range {
@@ -109,7 +108,7 @@ impl AsyncBackend for ObjectStoreBackend {
 
         let result = self.store.get_range(&self.path, range).await?;
 
-        Ok(result)
+        Ok(BackendResponse::new(result))
     }
 }
 

--- a/src/backends/object_store.rs
+++ b/src/backends/object_store.rs
@@ -105,13 +105,16 @@ impl AsyncBackend for ObjectStoreBackend {
         };
 
         let result = self.store.get_opts(&self.path, opts).await?;
-        let etag = result.meta.e_tag.clone();
+        let data_version = result
+            .meta
+            .e_tag
+            .clone()
+            .or_else(|| Some(result.meta.last_modified.to_rfc3339()));
         let bytes = result.bytes().await?;
 
-        Ok(if let Some(version) = etag {
-            BackendResponse::new_with_version(bytes, version)
-        } else {
-            BackendResponse::new(bytes)
+        Ok(match data_version {
+            Some(version) => BackendResponse::new_with_version(bytes, version),
+            None => BackendResponse::new(bytes),
         })
     }
 }

--- a/src/backends/object_store.rs
+++ b/src/backends/object_store.rs
@@ -104,11 +104,11 @@ impl AsyncBackend for ObjectStoreBackend {
             ..Default::default()
         };
 
-        let result = self.store.get_opts(&self.path, opts).await?;
+        let mut result = self.store.get_opts(&self.path, opts).await?;
         let data_version = result
             .meta
             .e_tag
-            .clone()
+            .take()
             .or_else(|| Some(result.meta.last_modified.to_rfc3339()));
         let bytes = result.bytes().await?;
 

--- a/src/backends/object_store.rs
+++ b/src/backends/object_store.rs
@@ -118,7 +118,10 @@ impl AsyncBackend for ObjectStoreBackend {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
     use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::{ObjectStore, PutOptions, PutPayload};
 
     use super::*;
     use crate::PmtError;
@@ -142,5 +145,21 @@ mod tests {
             result.unwrap_err(),
             PmtError::ObjectStore(object_store::Error::NotFound { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn test_read_returns_etag() {
+        let store = Box::new(InMemory::new());
+        let path = Path::from("test.bin");
+        let payload: PutPayload = Bytes::copy_from_slice(&[0u8; 64]).into();
+        store
+            .put_opts(&path, payload, PutOptions::default())
+            .await
+            .unwrap();
+
+        let backend = ObjectStoreBackend::new(store, path);
+
+        let response = backend.read(0, 64).await.unwrap();
+        assert!(response.data_version_string.is_some());
     }
 }

--- a/src/backends/object_store.rs
+++ b/src/backends/object_store.rs
@@ -9,8 +9,6 @@
 //! - memory and
 //! - custom implementations
 
-use std::ops::Range;
-
 use object_store::ObjectStore;
 use object_store::path::Path;
 
@@ -99,16 +97,22 @@ impl ObjectStoreBackend {
 
 impl AsyncBackend for ObjectStoreBackend {
     async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
-        use object_store::ObjectStoreExt;
+        use object_store::{GetOptions, GetRange};
 
-        let range = Range {
-            start: offset as u64,
-            end: offset as u64 + length as u64,
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(offset as u64..(offset + length) as u64)),
+            ..Default::default()
         };
 
-        let result = self.store.get_range(&self.path, range).await?;
+        let result = self.store.get_opts(&self.path, opts).await?;
+        let etag = result.meta.e_tag.clone();
+        let bytes = result.bytes().await?;
 
-        Ok(BackendResponse::new(result))
+        Ok(if let Some(version) = etag {
+            BackendResponse::new_with_version(bytes, version)
+        } else {
+            BackendResponse::new(bytes)
+        })
     }
 }
 

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -74,7 +74,16 @@ impl AsyncBackend for S3Backend {
         if response_bytes.len() > length {
             Err(ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(BackendResponse::new(response_bytes.clone()))
+            let headers = response.headers();
+            let data_version = headers
+                .get("etag")
+                .or_else(|| headers.get("last-modified"))
+                .cloned();
+
+            Ok(match data_version {
+                Some(v) => BackendResponse::new_with_version(response_bytes.clone(), v),
+                None => BackendResponse::new(response_bytes.clone()),
+            })
         }
     }
 }

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1,7 +1,9 @@
 use s3::Bucket;
 
 use crate::PmtError::ResponseBodyTooLong;
-use crate::{AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtResult};
+use crate::{
+    AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtResult,
+};
 
 impl AsyncPmTilesReader<S3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a bucket and path to the

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -1,8 +1,7 @@
-use bytes::Bytes;
 use s3::Bucket;
 
 use crate::PmtError::ResponseBodyTooLong;
-use crate::{AsyncBackend, AsyncPmTilesReader, DirectoryCache, NoCache, PmtResult};
+use crate::{AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtResult};
 
 impl AsyncPmTilesReader<S3Backend, NoCache> {
     /// Creates a new `PMTiles` reader from a bucket and path to the
@@ -58,7 +57,7 @@ impl S3Backend {
 }
 
 impl AsyncBackend for S3Backend {
-    async fn read(&self, offset: usize, length: usize) -> PmtResult<Bytes> {
+    async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
         let response = self
             .bucket
             .get_object_range(
@@ -73,7 +72,7 @@ impl AsyncBackend for S3Backend {
         if response_bytes.len() > length {
             Err(ResponseBodyTooLong(response_bytes.len(), length))
         } else {
-            Ok(response_bytes.clone())
+            Ok(BackendResponse::new(response_bytes.clone()))
         }
     }
 }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -296,8 +296,7 @@ mod tests {
 
             use flate2::read::GzDecoder;
 
-            use crate::writer::WriteTo as _;
-            use crate::writer::{Compressor, GzipCompressor, NoCompression};
+            use crate::writer::{Compressor, GzipCompressor, NoCompression, WriteTo as _};
 
             let dir = Directory::from_entries(entries);
             let mut buf = vec![];

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,9 @@ pub enum PmtError {
     /// An object store error occurred.
     #[error(transparent)]
     ObjectStore(#[from] object_store::Error),
+    /// The underlying data source was modified since the reader was created.
+    #[error("Underlying data source was modified")]
+    SourceModified,
     /// The tile coordinate is invalid.
     #[error("Invalid coordinate {0}/{1}/{2}")]
     InvalidCoordinate(u8, u32, u32),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "__async")]
 mod async_reader;
 #[cfg(feature = "__async")]
-pub use async_reader::{AsyncBackend, AsyncPmTilesReader};
+pub use async_reader::{AsyncBackend, AsyncPmTilesReader, BackendResponse};
 
 mod backends;
 #[allow(unused_imports, reason = "only a warning if no backends are enabled")]

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -5,11 +5,10 @@ use std::collections::hash_map::Entry;
 use std::hash::BuildHasherDefault;
 use std::io::{BufWriter, Seek, Write};
 
-use countio::Counter;
-use twox_hash::XxHash3_64;
-
 pub use compressor::Compressor;
 pub(crate) use compressor::{GzipCompressor, NoCompression};
+use countio::Counter;
+use twox_hash::XxHash3_64;
 
 use crate::header::{HEADER_SIZE, MAX_INITIAL_BYTES};
 use crate::{
@@ -500,11 +499,10 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use crate::tests::RASTER_FILE;
+    use crate::writer::GzipCompressor;
     use crate::{
         AsyncPmTilesReader, Compression, MmapBackend, PmTilesWriter, TileCoord, TileId, TileType,
     };
-
-    use super::GzipCompressor;
 
     fn get_temp_file_path(suffix: &str) -> std::io::Result<String> {
         let temp_file = NamedTempFile::with_suffix(suffix)?;


### PR DESCRIPTION
This addresses Issue #40.

Teaches `AsyncPmTilesReader` to perform a data version check on every read. If the data version has changed since construction, a new error `SourceModified` is returned.

The definition of "data version" is left up to each PMTiles backend, but is generally either an `ETag` header or equivalent, with fallback to a `Date-Modified` header or equivalent. These backends have data versions implemented in this PR:

- `AwsS3Backend`
- `HttpBackend`
- `ObjectStoreBackend`
- `S3Backend`

Tests were added for `HttpBackend` and `ObjectStoreBackend`, as well as the check logic in `AsyncPmTilesReader`.

Also:

- I'm not sure why, but for my local dev to work at all, I had to add `features=["tokio"]` for `object_store` in `Cargo.toml`. Without it the trait `WriteMultipart` was not available.