### PR TITLE
chore: update object_store dependency and fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ flate2 = { version = "1", optional = true }
 fmmap = { version = "0.4", default-features = false, optional = true }
 futures-util = { version = "0.3", optional = true }
 moka = { version = "0.12", optional = true, features = ["future"] }
-object_store = { version = "0.13", optional = true, default-features = false }
+object_store = { version = "0.13.2", optional = true, default-features = false, features = ["tokio"] }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
 rust-s3 = { version = "0.37.0", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -13,10 +13,10 @@ multiple-versions = "allow"
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
+    "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
-    "OpenSSL",
     "Unicode-3.0",
     "Zlib",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,12 @@
+[advisories]
+# rustls-webpki 0.101.7 vulnerabilities transitively pulled in via aws-sdk-s3.
+# This version of rustls-webpki is pulled in via a legacy feature flag, which we're not actually using.
+# See https://github.com/awslabs/aws-sdk-rust/issues/1339
+ignore = [
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+]
+
 [bans]
 # We have tons of these, not certain if this should be a goal to fix them all.
 # For now, just allow multiple versions of the same crate.

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ allow = [
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
+    "MPL-2.0",
     "Unicode-3.0",
     "Zlib",
 ]


### PR DESCRIPTION
in 0.13.2, object_store made tokio optional in a patch release

See:
https://github.com/apache/arrow-rs-object-store/pull/644

Ideally this would have been in a object_store 0.14.0 release.