### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.22.0...v0.23.0) - 2026-04-18
+
+### Added
+
+- [**breaking**] teach AsyncPmTilesReader to check data version strings ([#117](https://github.com/stadiamaps/pmtiles-rs/pull/117))
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#118](https://github.com/stadiamaps/pmtiles-rs/pull/118))
+
 ## [0.22.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.21.0...v0.22.0) - 2026-04-18
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `pmtiles`: 0.22.0 -> 0.23.0 (⚠ API breaking changes)

### ⚠ `pmtiles` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PmtError:SourceModified in /tmp/.tmp0vpAbi/pmtiles-rs/src/error.rs:90
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.22.0...v0.23.0) - 2026-04-18

### Added

- [**breaking**] teach AsyncPmTilesReader to check data version strings ([#117](https://github.com/stadiamaps/pmtiles-rs/pull/117))

### Other

- *(deps)* bump the all-actions-version-updates group across 1 directory with 2 updates ([#118](https://github.com/stadiamaps/pmtiles-rs/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).