### PR TITLE
feat: convert MBTiles and x/y/z tile directories to PMTiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Convert `MBTiles` and `x/y/z` tile directories into `PMTiles` via `mbtiles_to_pmtiles` and `tile_dir_to_pmtiles`, behind the new `mbtiles` and `tile-convert` features. Tiles are streamed in `TileId` order (clustered output), `TMS` rows are flipped to `XYZ`, and tile bytes are stored verbatim.
+
 ## [0.23.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.22.0...v0.23.0) - 2026-04-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ write = ["dep:countio", "dep:flate2", "dep:twox-hash"]
 object-store = ["__async", "dep:object_store"]
 brotli = ["dep:brotli", "async-compression/brotli"]
 zstd = ["dep:zstd", "async-compression/zstd"]
+# Convert other tile sources into PMTiles archives.
+tile-convert = ["write"]
+mbtiles = ["tile-convert", "dep:rusqlite", "dep:serde_json"]
 
 # Forward some of the common features to reqwest dependency
 reqwest-default = ["reqwest?/default"]
@@ -50,6 +53,8 @@ __all_non_conflicting = [
     "object-store",
     "brotli",
     "zstd",
+    "tile-convert",
+    "mbtiles",
 ]
 __async = ["dep:tokio", "async-compression/tokio"]
 __async-s3 = ["__async", "dep:rust-s3"]
@@ -73,6 +78,7 @@ futures-util = { version = "0.3", optional = true }
 moka = { version = "0.12", optional = true, features = ["future"] }
 object_store = { version = "0.13.2", optional = true, default-features = false, features = ["tokio"] }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
+rusqlite = { version = "0.32", optional = true, features = ["bundled"] }
 rust-s3 = { version = "0.37.0", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
@@ -91,6 +97,14 @@ tempfile = "3.13.0"
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }
 url = "2"
 mockito = "1"
+
+[[example]]
+name = "convert_mbtiles"
+required-features = ["mbtiles"]
+
+[[example]]
+name = "convert_tiledir"
+required-features = ["tile-convert"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ originally created by Brandon Liu for Protomaps.
   - Async `s3` (Rust-S3 + Tokio) for S3-compatible buckets
   - Async `s3`/`azure`/`gcp`/`fs`/`http`/`mem`/custom ([`object_store`](https://docs.rs/object_store))
 - Creating `PMTile` archives
+- Converting `MBTiles` and `x/y/z` tile directories into `PMTiles` (`mbtiles` / `tile-convert` features)
 
 ## Plans & TODOs
 
 - [ ] Documentation and example code
-- [ ] Support conversion to and from `MBTiles` + `x/y/z`
+- Conversion to and from `MBTiles` + `x/y/z`:
+  - [x] `MBTiles` → `PMTiles`
+  - [x] `x/y/z` tile directory → `PMTiles`
+  - [ ] `PMTiles` → `MBTiles` / `x/y/z`
 - [ ] Support additional backends (sync `mmap` and `http` at least)
 - [ ] Support additional async styles (e.g., `async-std`)
 
@@ -96,6 +100,24 @@ let mut writer = PmTilesWriter::new(TileType::Mvt).create(file).unwrap();
 let coord = TileCoord::new(0, 0, 0).unwrap();
 writer.add_tile(coord, &[/*...*/]).unwrap();
 writer.finalize().unwrap();
+```
+
+### Converting `MBTiles` or an `x/y/z` directory to `PMTiles`
+
+Both converters stream tiles in `PMTiles` (Hilbert) order, so the output is
+clustered and benefits from run-length and content de-duplication. `MBTiles`
+(and `gdal2tiles`' default mercator output) store rows in the `TMS` scheme; the
+`y` axis is flipped to the `XYZ` scheme `PMTiles` uses.
+
+```rust,no_run
+use pmtiles::{mbtiles_to_pmtiles, tile_dir_to_pmtiles, TileScheme, TileType};
+
+// MBTiles -> PMTiles (requires the `mbtiles` feature)
+mbtiles_to_pmtiles("input.mbtiles", "output.pmtiles").unwrap();
+
+// A directory of `z/x/y.webp` tiles -> PMTiles (requires the `tile-convert` feature).
+// Use `TileScheme::Xyz` for "slippy"/Google tiles (e.g. `gdal2tiles --xyz`).
+tile_dir_to_pmtiles("./tiles", "tiles.pmtiles", TileType::Webp, TileScheme::Tms).unwrap();
 ```
 
 ## Development

--- a/examples/convert_mbtiles.rs
+++ b/examples/convert_mbtiles.rs
@@ -1,0 +1,26 @@
+//! Convert an `MBTiles` archive into a `PMTiles` archive.
+//!
+//! ```sh
+//! cargo run --example convert_mbtiles --features mbtiles -- input.mbtiles output.pmtiles
+//! ```
+
+use pmtiles::mbtiles_to_pmtiles;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let (Some(src), Some(dst)) = (args.next(), args.next()) else {
+        eprintln!("usage: convert_mbtiles <input.mbtiles> <output.pmtiles>");
+        std::process::exit(2);
+    };
+
+    let stats = mbtiles_to_pmtiles(&src, &dst)?;
+
+    println!("Converted {src} -> {dst}");
+    println!("  tiles read:    {}", stats.tiles_read);
+    println!("  tiles written: {}", stats.tiles_written);
+    if let (Some(min), Some(max)) = (stats.min_zoom, stats.max_zoom) {
+        println!("  zoom range:    {min}..={max}");
+    }
+
+    Ok(())
+}

--- a/examples/convert_tiledir.rs
+++ b/examples/convert_tiledir.rs
@@ -1,0 +1,51 @@
+//! Convert a directory of `z/x/y.<ext>` tiles into a `PMTiles` archive.
+//!
+//! GDAL's `gdal2tiles.py` (mercator profile) writes tiles in the `TMS` scheme by
+//! default, so this example uses [`TileScheme::Tms`]. Pass `xyz` as the optional
+//! 4th argument for "slippy"/Google tiles (e.g. `gdal2tiles --xyz`).
+//!
+//! ```sh
+//! cargo run --example convert_tiledir --features tile-convert -- ./tiles out.pmtiles webp
+//! ```
+
+use pmtiles::{TileScheme, TileType, tile_dir_to_pmtiles};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let (Some(dir), Some(dst)) = (args.next(), args.next()) else {
+        eprintln!(
+            "usage: convert_tiledir <tile_dir> <output.pmtiles> [png|jpeg|webp|mvt] [tms|xyz]"
+        );
+        std::process::exit(2);
+    };
+
+    let tile_type = match args.next().as_deref() {
+        Some("png") => TileType::Png,
+        Some("jpeg" | "jpg") => TileType::Jpeg,
+        Some("mvt" | "pbf") => TileType::Mvt,
+        None | Some("webp") => TileType::Webp,
+        Some(other) => {
+            eprintln!("unknown tile type: {other}");
+            std::process::exit(2);
+        }
+    };
+    let scheme = match args.next().as_deref() {
+        Some("xyz") => TileScheme::Xyz,
+        None | Some("tms") => TileScheme::Tms,
+        Some(other) => {
+            eprintln!("unknown scheme: {other} (expected tms or xyz)");
+            std::process::exit(2);
+        }
+    };
+
+    let stats = tile_dir_to_pmtiles(&dir, &dst, tile_type, scheme)?;
+
+    println!("Converted {dir} -> {dst}");
+    println!("  tiles read:    {}", stats.tiles_read);
+    println!("  tiles written: {}", stats.tiles_written);
+    if let (Some(min), Some(max)) = (stats.min_zoom, stats.max_zoom) {
+        println!("  zoom range:    {min}..={max}");
+    }
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -35,6 +35,8 @@ check:
     cargo check --workspace --all-targets --no-default-features --features tilejson
     cargo check --workspace --all-targets --no-default-features --features write
     cargo check --workspace --all-targets --no-default-features --features brotli
+    cargo check --workspace --all-targets --no-default-features --features tile-convert
+    cargo check --workspace --all-targets --no-default-features --features mbtiles
 
 # Generate code coverage report to upload to codecov.io
 ci-coverage: env-info && \

--- a/src/convert/mbtiles.rs
+++ b/src/convert/mbtiles.rs
@@ -1,0 +1,363 @@
+//! `MBTiles` (`SQLite`) → `PMTiles` conversion.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use serde_json::{Map, Value};
+
+use super::{ArchiveMeta, Coverage, build_archive, flip_tms_xyz, gzip_compression};
+use crate::{Compression, ConvertStats, PmtError, PmtResult, TileCoord, TileId, TileType};
+
+/// Keys that map onto `PMTiles` header fields rather than the JSON metadata blob.
+const STRUCTURAL_METADATA_KEYS: [&str; 6] =
+    ["bounds", "center", "minzoom", "maxzoom", "format", "json"];
+
+/// Convert an `MBTiles` (`SQLite`) archive into a `PMTiles` archive.
+///
+/// `MBTiles` stores tile rows in the `TMS` scheme; they are flipped to the `XYZ`
+/// scheme `PMTiles` uses. The tile type and compression are taken from the
+/// `metadata` table's `format` field when present, and otherwise sniffed from
+/// the tile bytes. Tile data is stored verbatim — gzip-compressed vector tiles
+/// stay compressed and the header advertises [`Compression::Gzip`] accordingly.
+///
+/// Bounds, center and the zoom range are taken from the `metadata` table when
+/// available, falling back to values derived from the tiles themselves.
+///
+/// # Errors
+///
+/// Returns an error if the database cannot be opened or queried, a tile encodes
+/// an invalid coordinate, the metadata cannot be assembled into valid JSON, or
+/// writing the archive fails.
+pub fn mbtiles_to_pmtiles(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> PmtResult<ConvertStats> {
+    let conn = Connection::open_with_flags(
+        src.as_ref(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )?;
+
+    let meta = read_metadata(&conn)?;
+    let sample: Option<Vec<u8>> = conn
+        .query_row("SELECT tile_data FROM tiles LIMIT 1", [], |r| r.get(0))
+        .optional()?;
+
+    let tile_type = meta
+        .get("format")
+        .and_then(|f| tile_type_from_format(&f.to_ascii_lowercase()))
+        .or_else(|| sample.as_deref().map(sniff_tile_type))
+        .unwrap_or(TileType::Unknown);
+
+    let tile_compression = match tile_type {
+        TileType::Mvt => sample
+            .as_deref()
+            .map_or(Compression::None, gzip_compression),
+        _ => Compression::None,
+    };
+
+    // Pass 1: collect tile keys (no blobs) and accumulate coverage.
+    let mut keys = Vec::new();
+    let mut coverage = Coverage::default();
+    {
+        let mut stmt = conn.prepare("SELECT zoom_level, tile_column, tile_row FROM tiles")?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let z: i64 = row.get(0)?;
+            let col: i64 = row.get(1)?;
+            let tms: i64 = row.get(2)?;
+
+            let z =
+                u8::try_from(z).map_err(|_| PmtError::Conversion(format!("invalid zoom {z}")))?;
+            let x = u32::try_from(col)
+                .map_err(|_| PmtError::Conversion(format!("invalid tile_column {col}")))?;
+            let tms = u32::try_from(tms)
+                .map_err(|_| PmtError::Conversion(format!("invalid tile_row {tms}")))?;
+
+            let y = flip_tms_xyz(z, tms)?;
+            let coord = TileCoord::new(z, x, y)?;
+            coverage.observe(z, x, y);
+            keys.push(super::TileKey {
+                id: u64::from(TileId::from(coord)),
+                coord,
+                src: (z, x, tms),
+            });
+        }
+    }
+
+    let metadata = build_metadata_json(&meta)?;
+    let min_zoom = meta
+        .get("minzoom")
+        .and_then(|s| s.trim().parse::<u8>().ok())
+        .or_else(|| coverage.min_zoom());
+    let max_zoom = meta
+        .get("maxzoom")
+        .and_then(|s| s.trim().parse::<u8>().ok())
+        .or_else(|| coverage.max_zoom());
+    let bounds = meta
+        .get("bounds")
+        .and_then(|s| parse_bounds(s))
+        .or_else(|| coverage.bounds());
+    // Prefer an explicit center; otherwise derive one from whichever bounds we
+    // resolved, so the two stay consistent.
+    let center = meta
+        .get("center")
+        .and_then(|s| parse_center(s))
+        .or_else(|| {
+            bounds.map(|(w, s, e, n)| {
+                (
+                    f64::midpoint(w, e),
+                    f64::midpoint(s, n),
+                    min_zoom.unwrap_or(0),
+                )
+            })
+        });
+
+    // Pass 2: stream tile blobs in TileId order via an indexed point lookup.
+    let mut fetch_stmt = conn.prepare(
+        "SELECT tile_data FROM tiles WHERE zoom_level=?1 AND tile_column=?2 AND tile_row=?3",
+    )?;
+    let fetch = |src: &(u8, u32, u32)| -> PmtResult<Vec<u8>> {
+        let (z, x, tms) = *src;
+        let data: Option<Vec<u8>> = fetch_stmt
+            .query_row(params![i64::from(z), i64::from(x), i64::from(tms)], |row| {
+                row.get(0)
+            })
+            .optional()?;
+        Ok(data.unwrap_or_default())
+    };
+
+    build_archive(
+        dst.as_ref(),
+        &ArchiveMeta {
+            tile_type,
+            tile_compression,
+            metadata: &metadata,
+            bounds,
+            center,
+            min_zoom,
+            max_zoom,
+        },
+        keys,
+        fetch,
+    )
+}
+
+fn read_metadata(conn: &Connection) -> PmtResult<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    // The metadata table is optional; treat a missing table as empty metadata.
+    let Ok(mut stmt) = conn.prepare("SELECT name, value FROM metadata") else {
+        return Ok(map);
+    };
+    let rows = stmt.query_map([], |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, Option<String>>(1)?))
+    })?;
+    for row in rows {
+        let (name, value) = row?;
+        if let Some(value) = value {
+            map.insert(name, value);
+        }
+    }
+    Ok(map)
+}
+
+/// Build the `PMTiles` JSON metadata object from the `MBTiles` `metadata` table.
+///
+/// The contents of the `json` field (if it is a JSON object, e.g. carrying
+/// `vector_layers`) are merged in, and all non-structural string entries are
+/// preserved. Keys that map onto header fields are dropped from the JSON blob.
+fn build_metadata_json(meta: &HashMap<String, String>) -> PmtResult<String> {
+    let mut obj = Map::new();
+
+    if let Some(raw) = meta.get("json")
+        && let Ok(Value::Object(inner)) = serde_json::from_str::<Value>(raw)
+    {
+        for (k, v) in inner {
+            obj.insert(k, v);
+        }
+    }
+
+    for (k, v) in meta {
+        if STRUCTURAL_METADATA_KEYS.contains(&k.as_str()) {
+            continue;
+        }
+        obj.entry(k.clone())
+            .or_insert_with(|| Value::String(v.clone()));
+    }
+
+    serde_json::to_string(&Value::Object(obj))
+        .map_err(|e| PmtError::Conversion(format!("building metadata JSON failed: {e}")))
+}
+
+fn tile_type_from_format(format: &str) -> Option<TileType> {
+    Some(match format {
+        "pbf" | "mvt" => TileType::Mvt,
+        "png" => TileType::Png,
+        "jpg" | "jpeg" => TileType::Jpeg,
+        "webp" => TileType::Webp,
+        "avif" => TileType::Avif,
+        _ => return None,
+    })
+}
+
+/// Best-effort detection of the tile type from the leading bytes of a tile.
+fn sniff_tile_type(sample: &[u8]) -> TileType {
+    if sample.starts_with(&[0x89, b'P', b'N', b'G']) {
+        TileType::Png
+    } else if sample.starts_with(&[0xff, 0xd8]) {
+        TileType::Jpeg
+    } else if sample.len() >= 12 && &sample[0..4] == b"RIFF" && &sample[8..12] == b"WEBP" {
+        TileType::Webp
+    } else if sample.starts_with(&[0x1f, 0x8b]) {
+        // gzip — almost certainly a compressed vector tile.
+        TileType::Mvt
+    } else {
+        TileType::Unknown
+    }
+}
+
+fn parse_bounds(s: &str) -> Option<(f64, f64, f64, f64)> {
+    let parts: Vec<f64> = s.split(',').filter_map(|t| t.trim().parse().ok()).collect();
+    match parts.as_slice() {
+        [w, s, e, n] => Some((*w, *s, *e, *n)),
+        _ => None,
+    }
+}
+
+fn parse_center(s: &str) -> Option<(f64, f64, u8)> {
+    let mut parts = s.split(',');
+    let lon = parts.next()?.trim().parse().ok()?;
+    let lat = parts.next()?.trim().parse().ok()?;
+    let zoom = parts
+        .next()
+        .and_then(|p| p.trim().parse::<u8>().ok())
+        .unwrap_or(0);
+    Some((lon, lat, zoom))
+}
+
+#[cfg(test)]
+#[cfg(feature = "mmap-async-tokio")]
+mod tests {
+    use rusqlite::{Connection, params};
+    use tempfile::TempDir;
+
+    use super::mbtiles_to_pmtiles;
+    use crate::{AsyncPmTilesReader, Compression, MmapBackend, TileCoord, TileType};
+
+    fn make_mbtiles(path: &std::path::Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE metadata (name text, value text);
+             CREATE TABLE tiles (zoom_level integer, tile_column integer, tile_row integer, tile_data blob);
+             CREATE UNIQUE INDEX tile_index ON tiles (zoom_level, tile_column, tile_row);",
+        )
+        .unwrap();
+        for (name, value) in [
+            ("format", "png"),
+            ("name", "test-archive"),
+            ("bounds", "-180,-85,180,85"),
+            ("minzoom", "0"),
+            ("maxzoom", "1"),
+        ] {
+            conn.execute("INSERT INTO metadata VALUES (?1, ?2)", params![name, value])
+                .unwrap();
+        }
+        // TMS rows: (1,0,0) is the southern tile, (1,0,1) the northern one.
+        for (z, x, row, data) in [
+            (0i64, 0i64, 0i64, &b"root"[..]),
+            (1, 0, 0, &b"sw"[..]),
+            (1, 0, 1, &b"nw"[..]),
+        ] {
+            conn.execute(
+                "INSERT INTO tiles VALUES (?1, ?2, ?3, ?4)",
+                params![z, x, row, data],
+            )
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn mbtiles_roundtrip_flips_y_and_carries_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let mbtiles = tmp.path().join("in.mbtiles");
+        make_mbtiles(&mbtiles);
+
+        let out = tmp.path().join("out.pmtiles");
+        let stats = mbtiles_to_pmtiles(&mbtiles, &out).unwrap();
+        assert_eq!(stats.tiles_read, 3);
+        assert_eq!(stats.tiles_written, 3);
+        assert_eq!(stats.min_zoom, Some(0));
+        assert_eq!(stats.max_zoom, Some(1));
+
+        let backend = MmapBackend::try_from(out.to_str().unwrap()).await.unwrap();
+        let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        let header = reader.get_header();
+        assert_eq!(header.tile_type, TileType::Png);
+        assert_eq!(header.tile_compression, Compression::None);
+        assert_eq!(header.min_zoom, 0);
+        assert_eq!(header.max_zoom, 1);
+
+        // MBTiles TMS (1,0,0) -> PMTiles XYZ (1,0,1).
+        let t = reader
+            .get_tile(TileCoord::new(1, 0, 1).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*t, b"sw");
+        let t = reader
+            .get_tile(TileCoord::new(1, 0, 0).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*t, b"nw");
+
+        let metadata = reader.get_metadata().await.unwrap();
+        assert!(metadata.contains("test-archive"));
+        // Structural keys must not leak into the JSON blob.
+        assert!(!metadata.contains("minzoom"));
+    }
+
+    /// The de-duplicated `map` + `images` + `tiles` VIEW schema emitted by
+    /// tippecanoe / mbutil must convert just like the flat table schema.
+    #[tokio::test]
+    async fn mbtiles_view_schema_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let mbtiles = tmp.path().join("view.mbtiles");
+        let conn = Connection::open(&mbtiles).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE metadata (name text, value text);
+             CREATE TABLE map (zoom_level integer, tile_column integer, tile_row integer, tile_id text);
+             CREATE TABLE images (tile_data blob, tile_id text);
+             CREATE VIEW tiles AS
+                 SELECT map.zoom_level, map.tile_column, map.tile_row, images.tile_data
+                 FROM map JOIN images ON images.tile_id = map.tile_id;",
+        )
+        .unwrap();
+        conn.execute("INSERT INTO metadata VALUES ('format', 'png')", [])
+            .unwrap();
+        // Two map entries share one image (content de-duplication).
+        conn.execute(
+            "INSERT INTO images VALUES (?1, 'a')",
+            params![&b"shared"[..]],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO map VALUES (1, 0, 0, 'a')", [])
+            .unwrap();
+        conn.execute("INSERT INTO map VALUES (1, 1, 0, 'a')", [])
+            .unwrap();
+
+        let out = tmp.path().join("out.pmtiles");
+        let stats = mbtiles_to_pmtiles(&mbtiles, &out).unwrap();
+        assert_eq!(stats.tiles_read, 2);
+        assert_eq!(stats.tiles_written, 2);
+
+        let backend = MmapBackend::try_from(out.to_str().unwrap()).await.unwrap();
+        let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        // TMS (1,0,0) -> XYZ (1,0,1); TMS (1,1,0) -> XYZ (1,1,1).
+        for (x, y) in [(0, 1), (1, 1)] {
+            let t = reader
+                .get_tile(TileCoord::new(1, x, y).unwrap())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(&*t, b"shared");
+        }
+    }
+}

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -1,0 +1,426 @@
+//! Convert other tile sources into `PMTiles` archives.
+//!
+//! This module implements part of the crate roadmap: *conversion to `PMTiles`
+//! from `MBTiles` and `x/y/z` tile directories*.
+//!
+//! Entry points:
+//! - [`tile_dir_to_pmtiles`] — convert a directory of `z/x/y.<ext>` tiles.
+//! - [`mbtiles_to_pmtiles`] — convert an `MBTiles` (`SQLite`) archive (requires the `mbtiles` feature).
+//!
+//! Both stream tiles into the archive in `PMTiles` (Hilbert) `TileId` order, so
+//! the output is *clustered* and benefits from the writer's run-length and
+//! content de-duplication. Only tile *keys* are held in memory during a
+//! conversion; tile *data* is streamed one tile at a time.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use crate::{
+    Compression, MAX_ZOOM, PmTilesWriter, PmtError, PmtResult, TileCoord, TileId, TileType,
+};
+
+#[cfg(feature = "mbtiles")]
+mod mbtiles;
+#[cfg(feature = "mbtiles")]
+pub use mbtiles::mbtiles_to_pmtiles;
+
+/// Geographic bounds as `(min_lon, min_lat, max_lon, max_lat)` in degrees.
+type LonLatBounds = (f64, f64, f64, f64);
+/// A center point as `(lon, lat, zoom)`.
+type CenterPoint = (f64, f64, u8);
+
+/// The numbering scheme used for the `y` axis of a tile source.
+///
+/// `PMTiles` always uses [`Xyz`](TileScheme::Xyz) internally; this enum
+/// describes how a *source's* `y` value should be interpreted so it can be
+/// converted correctly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TileScheme {
+    /// `XYZ` ("Google"/"slippy") scheme, where `y` increases southward.
+    /// This is what `PMTiles` uses, and what `gdal2tiles --xyz` emits.
+    Xyz,
+    /// `TMS` scheme, where `y` increases northward. This is what `MBTiles`
+    /// stores, and what GDAL's default `gdal2tiles` mercator output uses.
+    Tms,
+}
+
+/// Statistics describing a completed conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConvertStats {
+    /// Number of tiles read from the source.
+    pub tiles_read: u64,
+    /// Number of (non-empty) tiles written to the archive.
+    pub tiles_written: u64,
+    /// Minimum zoom level present in the source, if any tiles were found.
+    pub min_zoom: Option<u8>,
+    /// Maximum zoom level present in the source, if any tiles were found.
+    pub max_zoom: Option<u8>,
+}
+
+/// A single tile location, with its `PMTiles` id precomputed for sorting and a
+/// source-specific token (`src`) used to fetch the tile bytes later.
+struct TileKey<K> {
+    id: u64,
+    coord: TileCoord,
+    src: K,
+}
+
+/// Accumulates the geographic extent of the converted tiles so that header
+/// bounds, center and zoom range can be derived when the source does not
+/// provide them explicitly.
+#[derive(Default)]
+struct Coverage {
+    /// zoom level -> `[min_x, max_x, min_y, max_y]` in `XYZ` tile coordinates.
+    zoom_extent: BTreeMap<u8, [u32; 4]>,
+}
+
+impl Coverage {
+    fn observe(&mut self, z: u8, x: u32, y: u32) {
+        let e = self.zoom_extent.entry(z).or_insert([x, x, y, y]);
+        e[0] = e[0].min(x);
+        e[1] = e[1].max(x);
+        e[2] = e[2].min(y);
+        e[3] = e[3].max(y);
+    }
+
+    fn min_zoom(&self) -> Option<u8> {
+        self.zoom_extent.keys().next().copied()
+    }
+
+    fn max_zoom(&self) -> Option<u8> {
+        self.zoom_extent.keys().next_back().copied()
+    }
+
+    /// Geographic bounds `(min_lon, min_lat, max_lon, max_lat)` derived from the
+    /// tile coverage at the finest (maximum) zoom level present.
+    fn bounds(&self) -> Option<LonLatBounds> {
+        let (&z, e) = self.zoom_extent.iter().next_back()?;
+        let west = tile_x_to_lon(e[0], z);
+        let east = tile_x_to_lon(e[1] + 1, z);
+        let north = tile_y_to_lat(e[2], z);
+        let south = tile_y_to_lat(e[3] + 1, z);
+        Some((west, south, east, north))
+    }
+
+    /// Bounds plus a derived center point `(lon, lat, zoom)`.
+    fn bounds_and_center(&self) -> (Option<LonLatBounds>, Option<CenterPoint>) {
+        match self.bounds() {
+            Some(b @ (w, s, e, n)) => {
+                let center = (
+                    f64::midpoint(w, e),
+                    f64::midpoint(s, n),
+                    self.min_zoom().unwrap_or(0),
+                );
+                (Some(b), Some(center))
+            }
+            None => (None, None),
+        }
+    }
+}
+
+/// Convert a directory of `z/x/y.<ext>` tiles into a `PMTiles` archive.
+///
+/// `tile_type` declares the encoding of the tiles (e.g. [`TileType::Webp`]); the
+/// bytes are stored verbatim — no re-encoding is performed. `scheme` selects how
+/// the `y` filename is interpreted: use [`TileScheme::Tms`] for GDAL
+/// `gdal2tiles` mercator output, or [`TileScheme::Xyz`] for "slippy"/Google
+/// tiles.
+///
+/// Bounds, center and the zoom range are derived from the tiles present.
+/// Non-numeric directory and file names are ignored, so sidecar files such as
+/// `tilemapresource.xml` or `*.aux.xml` are skipped automatically.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be read, a numerically-named tile
+/// encodes an out-of-range coordinate, or writing the archive fails.
+pub fn tile_dir_to_pmtiles(
+    tile_dir: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+    tile_type: TileType,
+    scheme: TileScheme,
+) -> PmtResult<ConvertStats> {
+    let tile_dir = tile_dir.as_ref();
+    let mut keys: Vec<TileKey<PathBuf>> = Vec::new();
+    let mut coverage = Coverage::default();
+
+    for z_entry in std::fs::read_dir(tile_dir)? {
+        let z_entry = z_entry?;
+        if !z_entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(z) = parse_u32(&z_entry.file_name()).and_then(|v| u8::try_from(v).ok()) else {
+            continue;
+        };
+        if z > MAX_ZOOM {
+            continue;
+        }
+
+        for x_entry in std::fs::read_dir(z_entry.path())? {
+            let x_entry = x_entry?;
+            if !x_entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(x) = parse_u32(&x_entry.file_name()) else {
+                continue;
+            };
+
+            for y_entry in std::fs::read_dir(x_entry.path())? {
+                let y_entry = y_entry?;
+                if !y_entry.file_type()?.is_file() {
+                    continue;
+                }
+                let path = y_entry.path();
+                let Some(y_raw) = path.file_stem().and_then(parse_u32) else {
+                    continue;
+                };
+                let y = match scheme {
+                    TileScheme::Xyz => y_raw,
+                    TileScheme::Tms => flip_tms_xyz(z, y_raw)?,
+                };
+                let coord = TileCoord::new(z, x, y)?;
+                coverage.observe(z, x, y);
+                keys.push(TileKey {
+                    id: u64::from(TileId::from(coord)),
+                    coord,
+                    src: path,
+                });
+            }
+        }
+    }
+
+    // Raster tiles are stored as-is. Vector tiles are often gzip-compressed on
+    // disk; sniff the first one so the header advertises the right encoding.
+    let tile_compression = if matches!(tile_type, TileType::Mvt) {
+        match keys.first() {
+            Some(k) => gzip_compression(&std::fs::read(&k.src)?),
+            None => Compression::None,
+        }
+    } else {
+        Compression::None
+    };
+
+    let (bounds, center) = coverage.bounds_and_center();
+    build_archive(
+        dst.as_ref(),
+        &ArchiveMeta {
+            tile_type,
+            tile_compression,
+            metadata: "{}",
+            bounds,
+            center,
+            min_zoom: coverage.min_zoom(),
+            max_zoom: coverage.max_zoom(),
+        },
+        keys,
+        |path| Ok(std::fs::read(path)?),
+    )
+}
+
+/// Header-level information for the archive being written, derived from the
+/// source before any tile data is streamed.
+struct ArchiveMeta<'a> {
+    tile_type: TileType,
+    tile_compression: Compression,
+    metadata: &'a str,
+    bounds: Option<LonLatBounds>,
+    center: Option<CenterPoint>,
+    min_zoom: Option<u8>,
+    max_zoom: Option<u8>,
+}
+
+/// Build a `PMTiles` archive from a set of tile keys and a `fetch` callback that
+/// returns the bytes for each key. Keys are sorted into `TileId` order before
+/// writing so the archive is clustered.
+fn build_archive<K, F>(
+    dst: &Path,
+    meta: &ArchiveMeta<'_>,
+    mut keys: Vec<TileKey<K>>,
+    mut fetch: F,
+) -> PmtResult<ConvertStats>
+where
+    F: FnMut(&K) -> PmtResult<Vec<u8>>,
+{
+    keys.sort_unstable_by_key(|k| k.id);
+
+    let mut builder = PmTilesWriter::new(meta.tile_type)
+        .tile_compression(meta.tile_compression)
+        .metadata(meta.metadata);
+    if let Some(z) = meta.min_zoom {
+        builder = builder.min_zoom(z);
+    }
+    if let Some(z) = meta.max_zoom {
+        builder = builder.max_zoom(z);
+    }
+    if let Some((min_lon, min_lat, max_lon, max_lat)) = meta.bounds {
+        builder = builder.bounds(min_lon, min_lat, max_lon, max_lat);
+    }
+    if let Some((lon, lat, zoom)) = meta.center {
+        builder = builder.center_zoom(zoom).center(lon, lat);
+    }
+
+    let mut writer = builder.create(File::create(dst)?)?;
+
+    let tiles_read = keys.len() as u64;
+    let mut tiles_written = 0u64;
+    for key in &keys {
+        let data = fetch(&key.src)?;
+        if data.is_empty() {
+            // The spec does not allow storing empty tiles; the writer ignores
+            // them too, but skip explicitly so the count stays accurate.
+            continue;
+        }
+        writer.add_raw_tile(key.coord, &data)?;
+        tiles_written += 1;
+    }
+    writer.finalize()?;
+
+    Ok(ConvertStats {
+        tiles_read,
+        tiles_written,
+        min_zoom: meta.min_zoom,
+        max_zoom: meta.max_zoom,
+    })
+}
+
+/// Convert a `TMS` `y` value to the `XYZ` value `PMTiles` uses, validating the
+/// coordinate against the zoom level.
+fn flip_tms_xyz(z: u8, y: u32) -> PmtResult<u32> {
+    let side = 1u32
+        .checked_shl(u32::from(z))
+        .ok_or(PmtError::InvalidCoordinate(z, 0, y))?;
+    if y >= side {
+        return Err(PmtError::InvalidCoordinate(z, 0, y));
+    }
+    Ok(side - 1 - y)
+}
+
+/// Returns [`Compression::Gzip`] if the sample begins with the gzip magic bytes,
+/// otherwise [`Compression::None`].
+fn gzip_compression(sample: &[u8]) -> Compression {
+    if sample.starts_with(&[0x1f, 0x8b]) {
+        Compression::Gzip
+    } else {
+        Compression::None
+    }
+}
+
+fn parse_u32(name: &OsStr) -> Option<u32> {
+    name.to_str()?.parse().ok()
+}
+
+/// Longitude (degrees) of the left edge of `XYZ` tile column `x` at zoom `z`.
+fn tile_x_to_lon(x: u32, z: u8) -> f64 {
+    let n = f64::from(1u32 << u32::from(z));
+    f64::from(x) / n * 360.0 - 180.0
+}
+
+/// Latitude (degrees) of the top edge of `XYZ` tile row `y` at zoom `z`.
+fn tile_y_to_lat(y: u32, z: u8) -> f64 {
+    let n = f64::from(1u32 << u32::from(z));
+    let lat_rad = (std::f64::consts::PI * (1.0 - 2.0 * f64::from(y) / n))
+        .sinh()
+        .atan();
+    lat_rad.to_degrees()
+}
+
+#[cfg(test)]
+#[cfg(feature = "mmap-async-tokio")]
+mod tests {
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::{TileScheme, tile_dir_to_pmtiles};
+    use crate::{AsyncPmTilesReader, Compression, MmapBackend, TileCoord, TileType};
+
+    fn write_tile(root: &Path, z: u8, x: u32, y: u32, data: &[u8]) {
+        let dir = root.join(z.to_string()).join(x.to_string());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{y}.png")), data).unwrap();
+    }
+
+    #[tokio::test]
+    async fn tms_dir_roundtrip_flips_y() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("tiles");
+        // z=1 TMS rows: row 0 is the southern row, row 1 the northern row.
+        write_tile(&dir, 1, 0, 0, b"sw");
+        write_tile(&dir, 1, 0, 1, b"nw");
+        write_tile(&dir, 0, 0, 0, b"root");
+        // A sidecar file that must be ignored.
+        std::fs::write(dir.join("1").join("0").join("tilemapresource.xml"), b"x").unwrap();
+
+        let out = tmp.path().join("out.pmtiles");
+        let stats = tile_dir_to_pmtiles(&dir, &out, TileType::Png, TileScheme::Tms).unwrap();
+        assert_eq!(stats.tiles_read, 3);
+        assert_eq!(stats.tiles_written, 3);
+        assert_eq!(stats.min_zoom, Some(0));
+        assert_eq!(stats.max_zoom, Some(1));
+
+        let backend = MmapBackend::try_from(out.to_str().unwrap()).await.unwrap();
+        let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        assert_eq!(reader.get_header().tile_type, TileType::Png);
+        assert_eq!(reader.get_header().tile_compression, Compression::None);
+
+        // TMS (1,0,0) (south) maps to XYZ (1,0,1).
+        let t = reader
+            .get_tile(TileCoord::new(1, 0, 1).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*t, b"sw");
+        // TMS (1,0,1) (north) maps to XYZ (1,0,0).
+        let t = reader
+            .get_tile(TileCoord::new(1, 0, 0).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*t, b"nw");
+    }
+
+    #[tokio::test]
+    async fn xyz_dir_no_flip() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("tiles");
+        write_tile(&dir, 1, 0, 0, b"a");
+
+        let out = tmp.path().join("out.pmtiles");
+        tile_dir_to_pmtiles(&dir, &out, TileType::Png, TileScheme::Xyz).unwrap();
+
+        let backend = MmapBackend::try_from(out.to_str().unwrap()).await.unwrap();
+        let reader = AsyncPmTilesReader::try_from_source(backend).await.unwrap();
+        let t = reader
+            .get_tile(TileCoord::new(1, 0, 0).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&*t, b"a");
+    }
+
+    #[test]
+    fn out_of_range_coordinate_errors() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("tiles");
+        // x=9 is invalid at z=1 (only 0..=1 allowed).
+        write_tile(&dir, 1, 9, 0, b"bad");
+        let out = tmp.path().join("out.pmtiles");
+        let err = tile_dir_to_pmtiles(&dir, &out, TileType::Png, TileScheme::Xyz);
+        assert!(matches!(
+            err,
+            Err(crate::PmtError::InvalidCoordinate(1, 9, 0))
+        ));
+    }
+
+    #[test]
+    fn flip_tms_xyz_validates() {
+        use super::flip_tms_xyz;
+        assert_eq!(flip_tms_xyz(0, 0).unwrap(), 0);
+        assert_eq!(flip_tms_xyz(1, 0).unwrap(), 1);
+        assert_eq!(flip_tms_xyz(1, 1).unwrap(), 0);
+        assert!(flip_tms_xyz(1, 2).is_err()); // y out of range for z=1
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,4 +97,12 @@ pub enum PmtError {
     /// Indicates an error occurred with the directory cache.
     #[error("An error occurred with the directory cache: {0}")]
     DirectoryCacheError(String),
+    #[cfg(feature = "tile-convert")]
+    /// A tile source could not be converted into a `PMTiles` archive.
+    #[error("Tile conversion error: {0}")]
+    Conversion(String),
+    #[cfg(feature = "mbtiles")]
+    /// An error occurred while reading the `MBTiles` `SQLite` database.
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub use cache::MokaCache;
 #[cfg(feature = "__async")]
 pub use cache::{DirCacheResult, DirectoryCache, HashMapCache, NoCache};
 
+#[cfg(feature = "tile-convert")]
+mod convert;
 mod directory;
 mod error;
 mod header;
@@ -29,6 +31,10 @@ mod writer;
 /// Re-export of crate exposed in our API to simplify dependency management
 #[cfg(feature = "__async-aws-s3")]
 pub use aws_sdk_s3;
+#[cfg(feature = "mbtiles")]
+pub use convert::mbtiles_to_pmtiles;
+#[cfg(feature = "tile-convert")]
+pub use convert::{ConvertStats, TileScheme, tile_dir_to_pmtiles};
 #[cfg(feature = "iter-async")]
 pub use directory::DirEntryCoordsIter;
 pub use directory::{DirEntry, Directory};


### PR DESCRIPTION
## Summary

Implements the **"to PMTiles"** half of the roadmap item *"Support conversion to and from `MBTiles` + `x/y/z`"* (and adds runnable example code, another open TODO). Two new opt-in features:

| Feature | Pulls in | Public API |
|---|---|---|
| `tile-convert` | `write` | `tile_dir_to_pmtiles(dir, dst, TileType, TileScheme)`, `ConvertStats`, `TileScheme { Xyz, Tms }` |
| `mbtiles` | `tile-convert` + `rusqlite` (bundled) + `serde_json` | `mbtiles_to_pmtiles(src, dst)` |

```rust
use pmtiles::{mbtiles_to_pmtiles, tile_dir_to_pmtiles, TileScheme, TileType};

mbtiles_to_pmtiles("in.mbtiles", "out.pmtiles")?;
tile_dir_to_pmtiles("./tiles", "out.pmtiles", TileType::Webp, TileScheme::Tms)?;
```

## Design

- **Clustered output:** tiles are streamed in `TileId` (Hilbert) order, so the writer's run-length encoding and content de-duplication engage and the archive is written `clustered = true`.
- **Memory-bounded:** only tile *keys* are held in memory; tile *data* is streamed one tile at a time (two-pass: collect keys → sort → indexed point-lookup).
- **TMS → XYZ:** `MBTiles` (and `gdal2tiles`' default mercator output) store rows in the `TMS` scheme; the `y` axis is flipped to the `XYZ` scheme `PMTiles` uses.
- **Bytes stored verbatim:** raster tiles are stored as-is; gzip-compressed vector tiles stay compressed with the header advertising `Compression::Gzip`. Tile type/compression come from the `metadata` `format` field, falling back to magic-byte sniffing.
- **Robust on bad input:** out-of-range coordinates and unreadable databases return a typed `PmtError` (new `Conversion` / `Sqlite` variants, feature-gated) — no panics. Both the flat `tiles` table and the de-duplicated `map`+`images`+`tiles` VIEW schema are supported.
- Bounds, center, zoom range and JSON metadata are carried over from `MBTiles` metadata, falling back to values derived from the tiles.

## Testing

- New unit/integration tests cover the TMS→XYZ flip (both sources), the flat and VIEW `MBTiles` schemas, metadata carry-over, and out-of-range coordinate errors.
- Full suite green: `cargo test`, `cargo fmt --check`, `clippy --all-targets -D warnings`, `rustdoc -D warnings`, and standalone per-feature `cargo check` (added `tile-convert` / `mbtiles` to the `justfile` check list and `__all_non_conflicting`).
- Output independently cross-checked with the Go `pmtiles` CLI (`pmtiles show`): spec version, tile type, bounds, zoom range, tile counts, `clustered: true`, and compression all verified.
- All new transitive dependencies are MIT / Apache-2.0, matching `deny.toml`'s allow-list.

## Notes for maintainers

- **Scope:** this PR is the `MBTiles`/`x-y-z` → `PMTiles` direction only. The reverse (`PMTiles` → `MBTiles`/`x-y-z`, async via the reader's `entries()` stream) is a natural follow-up if you'd like it.
- **`Cargo.lock.msrv`:** this adds `rusqlite`/`serde_json` to the dependency set, so the MSRV lock file likely needs regenerating for the `ci-test-msrv` job. Happy to do it if you point me at the expected toolchain, or you may prefer to regenerate it as part of merge.
- `rusqlite` uses the `bundled` feature so there's no system SQLite dependency; let me know if you'd rather link the system library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)