### PR TITLE
chore(deps): bump object_store to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ flate2 = { version = "1", optional = true }
 fmmap = { version = "0.4", default-features = false, optional = true }
 futures-util = { version = "0.3", optional = true }
 moka = { version = "0.12", optional = true, features = ["future"] }
-object_store = { version = "0.13.2", optional = true, default-features = false, features = ["tokio"] }
+object_store = { version = "0.14.0", optional = true, default-features = false, features = ["tokio"] }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
 rust-s3 = { version = "0.37.0", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ futures-util = { version = "0.3", optional = true }
 moka = { version = "0.12", optional = true, features = ["future"] }
 object_store = { version = "0.14.0", optional = true, default-features = false, features = ["tokio"] }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
-rust-s3 = { version = "0.37.0", optional = true, default-features = false, features = ["fail-on-err"] }
+rust-s3 = { version = "0.37.2", optional = true, default-features = false, features = ["fail-on-err"] }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "2"

--- a/deny.toml
+++ b/deny.toml
@@ -1,10 +1,14 @@
 [advisories]
-# rustls-webpki 0.101.7 vulnerabilities transitively pulled in via aws-sdk-s3.
-# This version of rustls-webpki is pulled in via a legacy feature flag, which we're not actually using.
-# See https://github.com/awslabs/aws-sdk-rust/issues/1339
 ignore = [
+    # rustls-webpki 0.101.7 vulnerabilities transitively pulled in via aws-sdk-s3.
+    # This version of rustls-webpki is pulled in via a legacy feature flag, which we're not actually using.
+    # See https://github.com/awslabs/aws-sdk-rust/issues/1339
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+    # quick-xml 0.38 advisories, transitively pulled in via rust-s3/aws-creds, which pin `quick-xml = "0.38"`.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [bans]
@@ -20,6 +24,7 @@ multiple-versions = "allow"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
+    "0BSD",
     "Apache-2.0",
     "BSD-3-Clause",
     "CC0-1.0",


### PR DESCRIPTION
Bumps `object_store` from 0.13.2 to 0.14.0.