### PR TITLE
chore: release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/stadiamaps/pmtiles-rs/compare/v0.23.0...v0.23.1) - 2026-07-10
+
+### Other
+
+- *(deps)* bump object_store to 0.14 ([#126](https://github.com/stadiamaps/pmtiles-rs/pull/126))
+
 ## [0.23.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.22.0...v0.23.0) - 2026-04-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `pmtiles`: 0.23.0 -> 0.23.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.1](https://github.com/stadiamaps/pmtiles-rs/compare/v0.23.0...v0.23.1) - 2026-07-10

### Other

- *(deps)* bump object_store to 0.14 ([#126](https://github.com/stadiamaps/pmtiles-rs/pull/126))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).