### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.23.1...v0.24.0) - 2026-08-11
+
+### Added
+
+- [**breaking**] replaced the `fmmap` dependency with `memmap2`
+- [**breaking**] removed the `reqwest-webpki-roots` and `reqwest-rustls-native-certs` features.
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group across 1 directory with 3 updates ([#129](https://github.com/stadiamaps/pmtiles-rs/pull/129))
+
 ## [0.23.1](https://github.com/stadiamaps/pmtiles-rs/compare/v0.23.0...v0.23.1) - 2026-07-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmtiles"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2024"
 authors = ["Luke Seelenbinder <luke.seelenbinder@stadiamaps.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `pmtiles`: 0.23.1 -> 0.24.0 (⚠ API breaking changes)

### ⚠ `pmtiles` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature reqwest-rustls-native-certs in the package's Cargo.toml
  feature reqwest-webpki-roots in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.0](https://github.com/stadiamaps/pmtiles-rs/compare/v0.23.1...v0.24.0) - 2026-08-11

### Added

- [**breaking**] replaced the `fmmap` dependency with `memmap2`
- [**breaking**] removed the `reqwest-webpki-roots` and `reqwest-rustls-native-certs` features.

### Other

- *(deps)* bump the all-actions-version-updates group across 1 directory with 3 updates ([#129](https://github.com/stadiamaps/pmtiles-rs/pull/129))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).