### PR TITLE
Upgrade dependencies & replace fmmap.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["__all_non_conflicting"]
 aws-s3-async = ["__async-aws-s3"]
 http-async = ["__async", "dep:reqwest"]
 iter-async = ["__async", "dep:async-stream", "dep:futures-util"]
-mmap-async-tokio = ["__async", "dep:fmmap", "fmmap?/tokio"]
+mmap-async-tokio = ["__async", "dep:memmap2", "tokio?/fs"]
 moka = ["__async", "dep:moka"]
 s3-async-native = ["__async-s3", "__async-s3-nativetls"]
 s3-async-rustls = ["__async-s3", "__async-s3-rustls"]
@@ -62,12 +62,12 @@ async-stream = { version = "0.3", optional = true }
 aws-sdk-s3 = { version = "1.49.0", optional = true }
 brotli = { version = "8.0.2", optional = true }
 zstd = { version = "0.13", optional = true }
-bytes = "1"
+bytes = "1.10"
 countio = { version = "0.3.0", optional = true }
 fast_hilbert = "2.0.1"
 flate2 = { version = "1", optional = true }
-fmmap = { version = "0.4", default-features = false, optional = true }
 futures-util = { version = "0.3", optional = true }
+memmap2 = { version = "0.9.11", optional = true }
 moka = { version = "0.12", optional = true, features = ["future"] }
 object_store = { version = "0.14.0", optional = true, default-features = false, features = ["tokio"] }
 reqwest = { version = "0.13.1", default-features = false, optional = true }
@@ -90,7 +90,10 @@ url = "2"
 mockito = "1"
 
 [lints.rust]
-unsafe_code = "forbid"
+# `deny` rather than `forbid`: the mmap backend must call the inherently-unsafe `Mmap::map`,
+# and opts in at that single site with an `#[expect(unsafe_code)]`. `forbid` cannot be
+# overridden anywhere, which would make a memory-mapped backend impossible to write.
+unsafe_code = "deny"
 missing_docs = "warn"
 unused_qualifications = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ zstd = ["dep:zstd", "async-compression/zstd"]
 reqwest-default = ["reqwest?/default"]
 reqwest-native-tls = ["reqwest?/native-tls"]
 reqwest-rustls = ["reqwest?/rustls"]
-reqwest-rustls-native-certs = ["reqwest?/rustls-native-certs"]
-reqwest-webpki-roots = ["reqwest?/webpki-roots"]
 
 #### These features are for the internal usage only
 # This is a list of features we use in docs.rs and other places where we want everything.
@@ -84,8 +82,7 @@ varint-rs = "2"
 
 [dev-dependencies]
 flate2 = "1"
-fmmap = { version = "0.4", features = ["tokio"] }
-reqwest = { version = "0.13.1", features = ["rustls", "webpki-roots"] }
+reqwest = { version = "0.13.1", features = ["rustls"] }
 rstest = "0.26.1"
 tempfile = "3.13.0"
 tokio = { version = "1", features = ["test-util", "macros", "rt"] }

--- a/src/backends/mmap.rs
+++ b/src/backends/mmap.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::path::Path;
 
-use bytes::Buf;
-use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt as _, AsyncOptions};
+use bytes::Bytes;
+use memmap2::Mmap;
 
 use crate::{
     AsyncBackend, AsyncPmTilesReader, BackendResponse, DirectoryCache, NoCache, PmtError, PmtResult,
@@ -12,6 +12,11 @@ impl AsyncPmTilesReader<MmapBackend, NoCache> {
     /// Creates a new `PMTiles` reader from a file path using the async mmap backend.
     ///
     /// Fails if `path` does not exist or is an invalid archive.
+    ///
+    /// # Safety of memory mapping
+    ///
+    /// See [`MmapBackend::try_from`] - the file must not be modified or truncated by another
+    /// process while this reader, or any tile data obtained from it, is alive.
     ///
     /// # Errors
     ///
@@ -29,6 +34,11 @@ impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<MmapBackend, C> {
     ///
     /// Fails if `path` does not exist or is an invalid archive.
     ///
+    /// # Safety of memory mapping
+    ///
+    /// See [`MmapBackend::try_from`] - the file must not be modified or truncated by another
+    /// process while this reader, or any tile data obtained from it, is alive.
+    ///
     /// # Errors
     ///
     /// This function will return an error if the
@@ -44,50 +54,202 @@ impl<C: DirectoryCache + Sync + Send> AsyncPmTilesReader<MmapBackend, C> {
 
 /// Backend for reading `PMTiles` from a memory-mapped file.
 pub struct MmapBackend {
-    file: AsyncMmapFile,
+    /// The entire mapping, viewed as [`Bytes`].
+    ///
+    /// [`Bytes::from_owner`] keeps the underlying [`Mmap`] alive for as long as this value, or
+    /// any slice taken from it, is alive. Reads are therefore zero-copy: they only bump a
+    /// reference count.
+    bytes: Bytes,
 }
 
 impl MmapBackend {
     /// Creates a new memory-mapped file backend.
     ///
+    /// # Safety of memory mapping
+    ///
+    /// Memory mapping requires that the file not be modified or truncated by another process for
+    /// as long as this backend, or any tile data returned from it, remains alive. If the file
+    /// is truncated, reads through the mapping abort the process (`SIGBUS` on Unix, an SEH
+    /// exception on Windows). Because tile data borrows directly from the mapping, that
+    /// requirement extends to the lifetime of the returned bytes, not just of this backend.
+    ///
+    /// Use a different backend if the file may change underneath you.
+    ///
     /// # Errors
     ///
     /// This function will return an error if the file cannot be opened for memory mapping.
     pub async fn try_from<P: AsRef<Path>>(p: P) -> PmtResult<Self> {
+        let file = tokio::fs::File::open(p)
+            .await
+            .map_err(|_| PmtError::UnableToOpenMmapFile)?
+            .into_std()
+            .await;
+
+        // SAFETY: Memory mapping a file is inherently unsafe - another process truncating or
+        // rewriting the file invalidates the mapped pages, and reading them is undefined
+        // behavior. That cannot be enforced from here, so the requirement is documented on
+        // this function and on every public constructor that reaches it.
+        #[expect(
+            unsafe_code,
+            reason = "mmap of a file cannot be made safe; the contract is documented on the constructors"
+        )]
+        let mmap = unsafe { Mmap::map(&file) }.map_err(|_| PmtError::UnableToOpenMmapFile)?;
+
         Ok(Self {
-            file: AsyncMmapFile::open_with_options(p, AsyncOptions::new().read(true))
-                .await
-                .map_err(|_| PmtError::UnableToOpenMmapFile)?,
+            bytes: Bytes::from_owner(mmap),
         })
     }
 }
 
-impl From<fmmap::error::Error> for PmtError {
-    fn from(_: fmmap::error::Error) -> Self {
-        Self::Reading(io::Error::from(io::ErrorKind::UnexpectedEof))
-    }
+/// The error returned when a read runs past the end of the mapping.
+fn eof() -> PmtError {
+    PmtError::Reading(io::Error::from(io::ErrorKind::UnexpectedEof))
 }
 
 impl AsyncBackend for MmapBackend {
     async fn read_exact(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
-        if self.file.len() >= offset + length {
-            Ok(BackendResponse::new(
-                self.file.reader(offset)?.copy_to_bytes(length),
-            ))
-        } else {
-            Err(PmtError::Reading(io::Error::from(
-                io::ErrorKind::UnexpectedEof,
-            )))
+        match offset
+            .checked_add(length)
+            .filter(|end| *end <= self.bytes.len())
+        {
+            Some(end) => Ok(BackendResponse::new(self.bytes.slice(offset..end))),
+            None => Err(eof()),
         }
     }
 
     async fn read(&self, offset: usize, length: usize) -> PmtResult<BackendResponse> {
-        let reader = self.file.reader(offset)?;
+        // An offset at exactly the end of the file is a valid empty read; past it is an error.
+        if offset > self.bytes.len() {
+            return Err(eof());
+        }
 
-        let read_length = length.min(reader.len());
+        // Clamp to what is actually left *after* `offset`. Short reads are the normal path
+        // here: the reader always asks for `MAX_INITIAL_BYTES` up front, which is more than
+        // the total size of a small archive.
+        let end = offset.saturating_add(length).min(self.bytes.len());
 
-        Ok(BackendResponse::new(
-            self.file.reader(offset)?.copy_to_bytes(read_length),
-        ))
+        Ok(BackendResponse::new(self.bytes.slice(offset..end)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::RASTER_FILE;
+
+    async fn backend() -> (MmapBackend, usize) {
+        let backend = MmapBackend::try_from(RASTER_FILE).await.unwrap();
+        let len = backend.bytes.len();
+        assert!(
+            len > 100,
+            "fixture is too small to exercise the bounds logic"
+        );
+        (backend, len)
+    }
+
+    #[tokio::test]
+    async fn read_whole_file() {
+        let (backend, len) = backend().await;
+        let expected = std::fs::read(RASTER_FILE).unwrap();
+
+        let res = backend.read(0, len).await.unwrap();
+        assert_eq!(res.bytes.len(), len);
+        assert_eq!(&res.bytes[..], &expected[..]);
+        assert!(res.data_version_string.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_clamps_to_eof_at_offset_zero() {
+        let (backend, len) = backend().await;
+
+        let res = backend.read(0, len * 2).await.unwrap();
+        assert_eq!(res.bytes.len(), len);
+    }
+
+    /// Regression test: clamping must account for `offset`, not just the total length.
+    #[tokio::test]
+    async fn read_clamps_relative_to_offset() {
+        let (backend, len) = backend().await;
+        let offset = len - 10;
+
+        let res = backend.read(offset, 100).await.unwrap();
+        assert_eq!(res.bytes.len(), 10);
+
+        let expected = std::fs::read(RASTER_FILE).unwrap();
+        assert_eq!(&res.bytes[..], &expected[offset..]);
+    }
+
+    #[tokio::test]
+    async fn read_at_eof_is_empty() {
+        let (backend, len) = backend().await;
+
+        let res = backend.read(len, 10).await.unwrap();
+        assert!(res.bytes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_past_eof_errors() {
+        let (backend, len) = backend().await;
+
+        assert!(matches!(
+            backend.read(len + 1, 10).await,
+            Err(PmtError::Reading(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_exact_matches_the_file() {
+        let (backend, _) = backend().await;
+        let expected = std::fs::read(RASTER_FILE).unwrap();
+
+        let res = backend.read_exact(20, 50).await.unwrap();
+        assert_eq!(&res.bytes[..], &expected[20..70]);
+    }
+
+    #[tokio::test]
+    async fn read_exact_past_eof_errors() {
+        let (backend, len) = backend().await;
+
+        assert!(matches!(
+            backend.read_exact(len - 5, 10).await,
+            Err(PmtError::Reading(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn read_exact_does_not_overflow() {
+        let (backend, _) = backend().await;
+
+        assert!(matches!(
+            backend.read_exact(usize::MAX, 1).await,
+            Err(PmtError::Reading(_))
+        ));
+    }
+
+    /// Reads must be views into the mapping, not copies of it. Two reads of the same range
+    /// return the same address; a copy would allocate a fresh buffer each time.
+    #[tokio::test]
+    async fn reads_are_zero_copy() {
+        let (backend, _) = backend().await;
+
+        let a = backend.read_exact(64, 32).await.unwrap().bytes;
+        let b = backend.read_exact(64, 32).await.unwrap().bytes;
+        assert_eq!(a.as_ptr(), b.as_ptr());
+
+        // ...and a read at a different offset lands the same distance further into the map.
+        let c = backend.read_exact(96, 32).await.unwrap().bytes;
+        assert_eq!(c.as_ptr() as usize - a.as_ptr() as usize, 32);
+    }
+
+    /// Reads must be independent of each other - there is no shared cursor.
+    #[tokio::test]
+    async fn reads_are_position_independent() {
+        let (backend, _) = backend().await;
+
+        let (a, b) = tokio::join!(backend.read_exact(0, 40), backend.read_exact(60, 40));
+        let expected = std::fs::read(RASTER_FILE).unwrap();
+
+        assert_eq!(&a.unwrap().bytes[..], &expected[0..40]);
+        assert_eq!(&b.unwrap().bytes[..], &expected[60..100]);
     }
 }


### PR DESCRIPTION
Upgrading dependencies, which, in turn, uncovered a soundness issue that `fmmap` was covering up, so we've dropped back to using `memmap2` for a better and more correct implementation.

NB: this should *not* be squashed.